### PR TITLE
Render overlay when payment flow begins, post messages to iframe from parent

### DIFF
--- a/client/html-iframe/src/merchant-example/app.js
+++ b/client/html-iframe/src/merchant-example/app.js
@@ -3,7 +3,9 @@ function setupPage () {
   document.querySelector('#merchantDomain').innerHTML = origin;
 }
 
-function setupPostMessageListener () {
+function setupPostMessageListener (overlayControls) {
+  const {showOverlay, hideOverlay} = overlayControls;
+
   window.addEventListener("message", (event) => {
     // It's very important to check that the `origin` is expected to prevent XSS attacks!
     if (event.origin !== "http://localhost:3000") {
@@ -14,17 +16,65 @@ function setupPostMessageListener () {
 
     const statusContainer = document.querySelector("#postMessageStatus");
 
-    if (eventName === "payment-flow-approved") {
+    if (eventName === "payment-flow-start") {
+      showOverlay();
+    } else if (eventName === "payment-flow-approved") {
       statusContainer.innerHTML = `🥳 approved, order id ${JSON.stringify(data)}`;
+      hideOverlay();
     } else if (eventName === "payment-flow-canceled") {
       statusContainer.innerHTML = `🙅 canceled, order id ${data.orderId}`;
+      hideOverlay();
     } else if (eventName === "payment-flow-error") {
       statusContainer.innerHTML = `😱 error, order id ${data.error.message}`;
+      hideOverlay();
     }
   });
 }
 
+function setupOverlay () {
+  const overlay = document.getElementById('overlayContainer');
+
+  const showOverlay = () => {
+    overlay.classList.remove('hidden');
+  };
+
+  const hideOverlay = () => {
+    overlay.classList.add('hidden');
+    sendPostMessageToChild({eventName: 'close-payment-window'});
+  };
+
+  const refocusPaymentWindow = () => {
+    sendPostMessageToChild({eventName: 'refocus-payment-window'});
+  };
+
+  const close = document.getElementById('overlayCloseButton');
+  close.addEventListener('click', hideOverlay);
+
+  const refocus = document.getElementById('overlayRefocusButton');
+  refocus.addEventListener('click', refocusPaymentWindow);
+
+  return {
+    showOverlay,
+    hideOverlay,
+  };
+}
+
 function onLoad() {
+  if (window.setupComplete) {
+    return;
+  }
+
   setupPage();
-  setupPostMessageListener();
+
+  const overlayControls = setupOverlay();
+
+  setupPostMessageListener(overlayControls);
+
+  window.setupComplete = true;
+}
+
+function sendPostMessageToChild (payload) {
+  const iframe = document.getElementById("iframeWrapper");
+  const childOrigin = new URL(iframe.getAttribute('src')).origin;
+  iframe.contentWindow.postMessage(payload, childOrigin);
 }

--- a/client/html-iframe/src/merchant-example/index.html
+++ b/client/html-iframe/src/merchant-example/index.html
@@ -6,10 +6,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <style>
+      body {
+        margin: 0;
+      }
+
+      #mainContainer {
+        padding: 10px;
+      }
+
       #extraHeight {
         height: 1000px;
         width: 100%;
         background: #00330044;
+      }
+
+      #overlayContainer {
+        position: absolute;
+        top: 0;
+        height: 100%;
+        width: 100%;
+        background: #000000aa;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      #overlayContainer.hidden {
+        display: none;
       }
     </style>
   </head>
@@ -20,29 +43,36 @@
       onload="onLoad()"
     ></script>
 
-    <h1>PayPal iframe Example</h1>
+    <div id="mainContainer">
+      <h1>PayPal iframe Example</h1>
 
-    <p>
-      <span>merchant page domain:</span>
-      <span id="merchantDomain"></span>
-    </p>
+      <p>
+        <span>merchant page domain:</span>
+        <span id="merchantDomain"></span>
+      </p>
 
-    <p>
-      <span>status from iframe: </span>
-      <span id="postMessageStatus">No messages 😴</span>
-    </p>
+      <p>
+        <span>status from iframe: </span>
+        <span id="postMessageStatus">No messages 😴</span>
+      </p>
 
-    <iframe
-        id="iframe-wrapper"
-        src="http://localhost:3000/?origin=http://localhost:3001"
-        sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
-        allow="payment"
-        width="800"
-        height="250"
-    ></iframe>
+      <iframe
+          id="iframeWrapper"
+          src="http://localhost:3000/?origin=http://localhost:3001"
+          sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+          allow="payment"
+          width="800"
+          height="250"
+      ></iframe>
 
-    <div id="extraHeight">
-      Some extra height
+      <div id="extraHeight">
+        Some extra height
+      </div>
+    </div>
+
+    <div id="overlayContainer" class="hidden">
+      <button id="overlayCloseButton">Close</button>
+      <button id="overlayRefocusButton">Refocus</button>
     </div>
   </body>
 </html>

--- a/client/html-iframe/src/paypal-iframe/index.html
+++ b/client/html-iframe/src/paypal-iframe/index.html
@@ -13,6 +13,11 @@
       <span id="iframeDomain"></span>
     </p>
 
+    <p>
+      <span>last message from parent: </span>
+      <span id="postMessageStatus">No messages 😴</span>
+    </p>
+
     <paypal-button id="paypal-button"></paypal-button>
 
     <script src="/pageSetup.js"></script>


### PR DESCRIPTION
This PR sets the stage for a custom merchant overlay that can close the payment flow or refocus the payment window. Once the SDK exposes the ability to focus and close, I'll complete this example in a new PR.