### PR TITLE
Use npm start and other minor cleanup

### DIFF
--- a/server/node/README.md
+++ b/server/node/README.md
@@ -5,5 +5,5 @@ Node.js [Express](https://expressjs.com/) server that provides several endpoints
 Start the server by running:
 
 ```
-npm run dev
+npm start
 ```

--- a/server/node/package-lock.json
+++ b/server/node/package-lock.json
@@ -18,6 +18,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.13.9",
+        "@types/semver": "^7.5.8",
         "prettier": "^3.5.3",
         "semver": "^7.7.1",
         "tsx": "^4.19.3",
@@ -297,6 +298,13 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.4",

--- a/server/node/package.json
+++ b/server/node/package.json
@@ -2,15 +2,15 @@
   "name": "v6-web-sdk-sample-integration-server",
   "version": "1.0.0",
   "private": true,
-  "description": "",
+  "description": "Node.js Express server that provides several routes that wrap the PayPal APIs",
   "main": "src/server.ts",
   "scripts": {
-    "build": "npm run clean && tsc",
+    "build": "rm -rf dist && tsc",
     "check-node-version": "tsx src/checkNodeVersion.ts",
     "clean": "rm -rf dist",
-    "dev": "npm run check-node-version && tsx --watch src/server.ts",
-    "start": "NODE_ENV=production node dist/server.js",
-    "format": "npx prettier . --write"
+    "format": "prettier . --write",
+    "start": "npm run check-node-version && tsx --watch src/server.ts",
+    "start-production": "NODE_ENV=production node dist/server.js"
   },
   "license": "ISC",
   "dependencies": {
@@ -23,6 +23,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.9",
+    "@types/semver": "^7.5.8",
     "prettier": "^3.5.3",
     "semver": "^7.7.1",
     "tsx": "^4.19.3",

--- a/server/node/src/checkNodeVersion.ts
+++ b/server/node/src/checkNodeVersion.ts
@@ -1,12 +1,13 @@
-const { readFileSync } = require("fs");
-const { join } = require("path");
-const semver = require("semver");
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { satisfies } from "semver";
 
 const minimumNodeVersion = readFileSync(
   join(__dirname, "../", ".nvmrc"),
   "utf-8",
 );
-const isValidNodeVersion = semver.satisfies(
+
+const isValidNodeVersion = satisfies(
   process.version,
   `>= ${minimumNodeVersion}`,
 );

--- a/server/node/src/paypalServerSdk.ts
+++ b/server/node/src/paypalServerSdk.ts
@@ -13,6 +13,8 @@ import {
   OrdersController,
 } from "@paypal/paypal-server-sdk";
 
+import type { OrderRequest } from "@paypal/paypal-server-sdk";
+
 /* ######################################################################
  * Set up PayPal controllers
  * ###################################################################### */
@@ -71,19 +73,9 @@ export async function getBrowserSafeClientToken() {
  * Process transactions
  * ###################################################################### */
 
-export async function createOrder() {
+export async function createOrder(orderRequestBody: OrderRequest) {
   const { body, ...httpResponse } = await ordersController.ordersCreate({
-    body: {
-      intent: CheckoutPaymentIntent.Capture,
-      purchaseUnits: [
-        {
-          amount: {
-            currencyCode: "USD",
-            value: "100.00",
-          },
-        },
-      ],
-    },
+    body: orderRequestBody,
     prefer: "return=minimal",
   });
 
@@ -91,6 +83,21 @@ export async function createOrder() {
     jsonResponse: JSON.parse(String(body)),
     httpStatusCode: httpResponse.statusCode,
   };
+}
+
+export async function createOrderWithSampleData() {
+  const defaultOrderRequestBody = {
+    intent: CheckoutPaymentIntent.Capture,
+    purchaseUnits: [
+      {
+        amount: {
+          currencyCode: "USD",
+          value: "100.00",
+        },
+      },
+    ],
+  };
+  return createOrder(defaultOrderRequestBody);
 }
 
 export async function captureOrder(orderId: string) {

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -3,7 +3,7 @@ import cors from "cors";
 
 import {
   getBrowserSafeClientToken,
-  createOrder,
+  createOrderWithSampleData,
   captureOrder,
 } from "./paypalServerSdk";
 
@@ -36,7 +36,8 @@ app.post(
   "/paypal-api/checkout/orders/create",
   async (req: Request, res: Response) => {
     try {
-      const { jsonResponse, httpStatusCode } = await createOrder();
+      const { jsonResponse, httpStatusCode } =
+        await createOrderWithSampleData();
       res.status(httpStatusCode).json(jsonResponse);
     } catch (error) {
       console.error("Failed to create order:", error);


### PR DESCRIPTION
This PR includes a few changes for the server code:
- Teach `npm start` for local dev and have a separate `npm run start-production` for starting the server from dist.
- Use ECMAScript modules for all server code
- Add the new function `createOrderWithSampleData()` to make it clear that we are creating an order with hardcoded data.