### PR TITLE
iframe example, fix payment session after close

### DIFF
--- a/client/html-iframe/src/paypal-iframe/integration.js
+++ b/client/html-iframe/src/paypal-iframe/integration.js
@@ -154,11 +154,6 @@ async function setupPayPalButton() {
       clientToken,
       components: ["paypal-payments"],
     });
-    pageState.paymentSession = sdkInstance.createPayPalOneTimePaymentSession({
-      onApprove,
-      onCancel,
-      onError,
-    });
 
     async function onClick() {
       const paymentFlowConfig = {
@@ -172,6 +167,12 @@ async function setupPayPalButton() {
       });
 
       try {
+        pageState.paymentSession =
+          sdkInstance.createPayPalOneTimePaymentSession({
+            onApprove,
+            onCancel,
+            onError,
+          });
         await pageState.paymentSession.start(paymentFlowConfig, createOrder());
       } catch (e) {
         pageState.clearPaymentSession();


### PR DESCRIPTION
This PR ensures that, when the PayPal button is clicked, a new payment session is available after the previous one has ended.