### PR TITLE
feat: leverage ApiError for echoing api errors

### DIFF
--- a/client/html/src/paymentHandler/index.html
+++ b/client/html/src/paymentHandler/index.html
@@ -10,7 +10,7 @@
 
     <paypal-button id="paypal-button"></paypal-button>
 
-    <script src="/app.js"></script>
+    <script src="app.js"></script>
 
     <script
       async

--- a/server/node/src/paypalServerSdk.ts
+++ b/server/node/src/paypalServerSdk.ts
@@ -5,6 +5,7 @@ const envFilePath = join(__dirname, "../../../", ".env");
 config({ path: envFilePath });
 
 import {
+  ApiError,
   CheckoutPaymentIntent,
   Client,
   Environment,
@@ -51,22 +52,34 @@ const oAuthAuthorizationController = new OAuthAuthorizationController(client);
  * ###################################################################### */
 
 export async function getBrowserSafeClientToken() {
-  const auth = Buffer.from(
-    `${PAYPAL_SANDBOX_CLIENT_ID}:${PAYPAL_SANDBOX_CLIENT_SECRET}`,
-  ).toString("base64");
+  try {
+    const auth = Buffer.from(
+      `${PAYPAL_SANDBOX_CLIENT_ID}:${PAYPAL_SANDBOX_CLIENT_SECRET}`,
+    ).toString("base64");
 
-  const { body, ...httpResponse } =
-    await oAuthAuthorizationController.requestToken(
-      {
-        authorization: `Basic ${auth}`,
-      },
-      { response_type: "client_token" },
-    );
+    const { body, statusCode } =
+      await oAuthAuthorizationController.requestToken(
+        {
+          authorization: `Basic ${auth}`,
+        },
+        { response_type: "client_token" },
+      );
 
-  return {
-    jsonResponse: JSON.parse(String(body)),
-    httpStatusCode: httpResponse.statusCode,
-  };
+    return {
+      jsonResponse: JSON.parse(String(body)),
+      httpStatusCode: statusCode,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      const { statusCode, body } = error;
+      return {
+        jsonResponse: JSON.parse(String(body)),
+        httpStatusCode: statusCode,
+      };
+    } else {
+      throw error;
+    }
+  }
 }
 
 /* ######################################################################
@@ -74,15 +87,27 @@ export async function getBrowserSafeClientToken() {
  * ###################################################################### */
 
 export async function createOrder(orderRequestBody: OrderRequest) {
-  const { body, ...httpResponse } = await ordersController.ordersCreate({
-    body: orderRequestBody,
-    prefer: "return=minimal",
-  });
+  try {
+    const { body, statusCode } = await ordersController.ordersCreate({
+      body: orderRequestBody,
+      prefer: "return=minimal",
+    });
 
-  return {
-    jsonResponse: JSON.parse(String(body)),
-    httpStatusCode: httpResponse.statusCode,
-  };
+    return {
+      jsonResponse: JSON.parse(String(body)),
+      httpStatusCode: statusCode,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      const { statusCode, body } = error;
+      return {
+        jsonResponse: JSON.parse(String(body)),
+        httpStatusCode: statusCode,
+      };
+    } else {
+      throw error;
+    }
+  }
 }
 
 export async function createOrderWithSampleData() {
@@ -101,13 +126,25 @@ export async function createOrderWithSampleData() {
 }
 
 export async function captureOrder(orderId: string) {
-  const { body, ...httpResponse } = await ordersController.ordersCapture({
-    id: orderId,
-    prefer: "return=minimal",
-  });
+  try {
+    const { body, statusCode } = await ordersController.ordersCapture({
+      id: orderId,
+      prefer: "return=minimal",
+    });
 
-  return {
-    jsonResponse: JSON.parse(String(body)),
-    httpStatusCode: httpResponse.statusCode,
-  };
+    return {
+      jsonResponse: JSON.parse(String(body)),
+      httpStatusCode: statusCode,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      const { statusCode, body } = error;
+      return {
+        jsonResponse: JSON.parse(String(body)),
+        httpStatusCode: statusCode,
+      };
+    } else {
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
I learned that the Server SDK supports getting at the status code for errors if the error is an instance of ApiError: https://github.com/paypal/PayPal-TypeScript-Server-SDK/blob/0.6.1/doc/controllers/orders.md#example-usage.

With this change, the error status code and error body is returned back to the browser. Here are a few screenshots:

## 1. Invalid Client ID used to generate the clientToken
<img width="1957" alt="Screenshot 2025-03-07 at 12 26 54 PM" src="https://github.com/user-attachments/assets/7687588c-24c7-433c-9ff7-ebd377d724b2" />


## 2. Create Order error for an negative dollar amount
<img width="1954" alt="Screenshot 2025-03-07 at 12 27 24 PM" src="https://github.com/user-attachments/assets/778b5a59-eabd-4da8-ad99-dfbf39bfbac5" />
<img width="1915" alt="Screenshot 2025-03-07 at 12 27 15 PM" src="https://github.com/user-attachments/assets/051fc91f-37a7-4cbd-9096-4ad279356a3a" />

