### PR TITLE
More small improvements to the iframe example

### DIFF
--- a/client/one-time-payment/html/src/custom/sandboxedIframe/src/merchant-example/app.js
+++ b/client/one-time-payment/html/src/custom/sandboxedIframe/src/merchant-example/app.js
@@ -98,8 +98,11 @@ function setupOverlay() {
     sendPostMessageToChild({ eventName: "close-payment-window" });
   };
 
-  const close = document.getElementById("overlayCloseButton");
-  close.addEventListener("click", hideOverlay);
+  const closeCTA = document.getElementById("overlayCloseButtonCTA");
+  closeCTA.addEventListener("click", hideOverlay);
+
+  const closeBackdrop = document.getElementById("overlayCloseButtonBackdrop");
+  closeBackdrop.addEventListener("click", hideOverlay);
 }
 
 function onLoad() {

--- a/client/one-time-payment/html/src/custom/sandboxedIframe/src/merchant-example/index.html
+++ b/client/one-time-payment/html/src/custom/sandboxedIframe/src/merchant-example/index.html
@@ -17,7 +17,9 @@
         --theme-color-primary: #334037;
         --theme-color-secondary: #93e3ab;
         --theme-color-accent: #62dc87;
+        --theme-color-overlay-cta: #ffffff;
         --theme-color-overlay-background: #000000aa;
+        --theme-color-overlay-background-close-text: #cccccc;
       }
 
       body {
@@ -53,11 +55,31 @@
       }
 
       #overlayContainer {
-        background: var(--theme-color-background);
+        background: none;
+        border: none;
+        overflow: visible;
+        text-align: center;
       }
 
-      #overlayCloseButton {
-        background: var(--theme-color-secondary);
+      #overlayContainerLogo {
+        margin-bottom: 10px;
+      }
+
+      #overlayCloseButtonCTA {
+        background: var(--theme-color-overlay-cta);
+        cursor: pointer;
+        border-radius: 20px;
+        padding: 10px 20px;
+      }
+
+      #overlayCloseButtonBackdrop {
+        background: none;
+        color: var(--theme-color-overlay-background-close-text);
+        position: fixed;
+        top: 0;
+        right: 0;
+        font-size: 1.5em;
+        cursor: pointer;
       }
 
       #overlayContainer::backdrop {
@@ -125,7 +147,11 @@
     </div>
 
     <dialog id="overlayContainer">
-      <button id="overlayCloseButton">Close</button>
+      <div id="overlayContainerLogo">
+        <img src="https://www.paypalobjects.com/js-sdk-logos/2.2.7/paypal-white.svg" />
+      </div>
+      <button id="overlayCloseButtonCTA">Close</button>
+      <button id="overlayCloseButtonBackdrop">X</button>
     </dialog>
   </body>
 </html>

--- a/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/index.html
+++ b/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/index.html
@@ -52,7 +52,6 @@
       <fieldset>
         <legend>presentationMode</legend>
         <div>
-          <label for="presentationMode-popup">popup</label>
           <input
             checked
             type="radio"
@@ -60,15 +59,25 @@
             name="presentationMode"
             value="popup"
           />
+          <label for="presentationMode-popup">popup</label>
         </div>
         <div>
-          <label for="presentationMode-modal">modal</label>
           <input
             type="radio"
             id="presentationMode-modal"
             name="presentationMode"
             value="modal"
           />
+          <label for="presentationMode-modal">modal</label>
+        </div>
+        <div>
+          <input
+            type="radio"
+            id="presentationMode-payment-handler"
+            name="presentationMode"
+            value="payment-handler"
+          />
+          <label for="presentationMode-modal">payment-handler</label>
         </div>
       </fieldset>
     </div>

--- a/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/integration.js
+++ b/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/integration.js
@@ -14,35 +14,6 @@ class PageState {
 
 const pageState = new PageState();
 
-async function onApprove(data) {
-  const orderData = await captureOrder({
-    orderId: data.orderId,
-  });
-
-  sendPostMessageToParent({
-    eventName: "payment-flow-approved",
-    data: orderData,
-  });
-}
-
-function onCancel(data) {
-  sendPostMessageToParent({
-    eventName: "payment-flow-canceled",
-    data: {
-      orderId: data?.orderId,
-    },
-  });
-}
-
-function onError(data) {
-  sendPostMessageToParent({
-    eventName: "payment-flow-error",
-    data: {
-      error: data?.error,
-    },
-  });
-}
-
 function getParentOrigin() {
   const parentOrigin = new URLSearchParams(window.location.search).get(
     "origin",
@@ -105,9 +76,32 @@ function setupIframeOriginDisplay() {
 
 async function setupPayPalButton(sdkInstance) {
   pageState.paymentSession = sdkInstance.createPayPalOneTimePaymentSession({
-    onApprove,
-    onCancel,
-    onError,
+    onApprove: async (data) => {
+      const orderData = await captureOrder({
+        orderId: data.orderId,
+      });
+
+      sendPostMessageToParent({
+        eventName: "payment-flow-approved",
+        data: orderData,
+      });
+    },
+    onCancel: (data) => {
+      sendPostMessageToParent({
+        eventName: "payment-flow-canceled",
+        data: {
+          orderId: data?.orderId,
+        },
+      });
+    },
+    onError: (data) => {
+      sendPostMessageToParent({
+        eventName: "payment-flow-canceled",
+        data: {
+          orderId: data?.orderId,
+        },
+      });
+    },
   });
 
   const paypalButton = document.querySelector("#paypal-button");


### PR DESCRIPTION
This PR contains a few improvements for the iframe example:

- Adds a `payment-handler` radio button option, so that flow can be demoed.
- Adds a close button the `popup` payment flow overlay, a PayPal logo, and some other styling improvements.
- Moves the payment callback function definitions to where they're used, similar to other implementation examples.