### PR TITLE
fix payment-handler radio button

### DIFF
--- a/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/index.html
+++ b/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/index.html
@@ -77,7 +77,7 @@
             name="presentationMode"
             value="payment-handler"
           />
-          <label for="presentationMode-modal">payment-handler</label>
+          <label for="presentationMode-payment-handler">payment-handler</label>
         </div>
       </fieldset>
     </div>


### PR DESCRIPTION
I had the wrong `for` on the `payment-handler` label. This fixes that so it's selectable.