### PR TITLE
chore: update fallback logic for the payment handler use case

### DIFF
--- a/client/one-time-payment/html/src/custom/sandboxedIframe/src/merchant-example/index.html
+++ b/client/one-time-payment/html/src/custom/sandboxedIframe/src/merchant-example/index.html
@@ -148,7 +148,9 @@
 
     <dialog id="overlayContainer">
       <div id="overlayContainerLogo">
-        <img src="https://www.paypalobjects.com/js-sdk-logos/2.2.7/paypal-white.svg" />
+        <img
+          src="https://www.paypalobjects.com/js-sdk-logos/2.2.7/paypal-white.svg"
+        />
       </div>
       <button id="overlayCloseButtonCTA">Close</button>
       <button id="overlayCloseButtonBackdrop">X</button>


### PR DESCRIPTION
This PR updates the payment handler demo with the following fallback logic: `payment-handler` => `popup` => `modal`