### PR TITLE
chore(readme): Add description for server endpoints

### DIFF
--- a/server/node/README.md
+++ b/server/node/README.md
@@ -7,3 +7,72 @@ Start the server by running:
 ```bash
 npm start
 ```
+
+---
+
+### `GET /paypal-api/auth/browser-safe-client-token`
+
+**Description:**  
+Generates and returns a browser-safe client token for initializing the PayPal JavaScript SDK on the client side.
+
+**Responses:**
+
+- `200 OK`  
+  Returns a JSON object with the client token.
+
+  ```json
+  {
+    "client_token": "abc123..."
+  }
+  ```
+
+- `500 Internal Server Error` returned if token generation fails.
+
+---
+
+### `POST /paypal-api/checkout/orders/create`
+
+**Description:**  
+Creates a new PayPal order with sample data. This simulates the beginning of a checkout session.
+
+**Request Body:**
+No body required.
+
+**Responses:**
+
+- `201 Created`  
+  Returns the new order's details.
+
+  ```json
+  {
+    "id": "ORDER-ID",
+    "status": "CREATED"
+  }
+  ```
+
+- `500 Internal Server Error` returned if order creation fails.
+
+---
+
+### `POST /paypal-api/checkout/orders/{orderId}/capture`
+
+**Description:**  
+Captures an existing PayPal order and finalizes the payment.
+
+**Path Parameters:**
+
+- `orderId` (string): The ID of the order to be captured.
+
+**Responses:**
+
+- `200 OK`  
+  Returns capture confirmation.
+
+  ```json
+  {
+    "id": "ORDER-ID",
+    "status": "COMPLETED"
+  }
+  ```
+
+- `500 Internal Server Error` returned if the capture fails.

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -49,7 +49,6 @@ No body required.
   }
   ```
 
-- `500 Internal Server Error` returned if order creation fails.
 
 ---
 

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -27,6 +27,7 @@ Generates and returns a browser-safe client token for initializing the PayPal Ja
     // additional metadata
   }
   ```
+  For more details, visit PayPal's [Developer Documentation](https://developer.paypal.com/api/rest/authentication/) site 
 
 
 ---
@@ -50,6 +51,7 @@ No body required.
     "status": "CREATED"
   }
   ```
+  For more information on the Create endpoint, visit PayPal's [Developer Documentation](https://developer.paypal.com/docs/api/orders/v2/#orders_create) site.
 
 
 ---
@@ -71,7 +73,10 @@ Captures an existing PayPal order and finalizes the payment.
   ```json
   {
     "id": "ORDER-ID",
-    "status": "COMPLETED"
+    "status": "COMPLETED",
+    // additional order information
   }
   ```
+  
+  For more information on the Capture endpoint, visit PayPal's [Developer Documentation](https://developer.paypal.com/docs/api/orders/v2/#orders_capture) site.
 

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -22,7 +22,9 @@ Generates and returns a browser-safe client token for initializing the PayPal Ja
 
   ```json
   {
-    "client_token": "abc123..."
+    "access_token": "abc123...",
+    "expires_in": "900" // TTL in seconds,
+    // additional metadata
   }
   ```
 

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -74,4 +74,3 @@ Captures an existing PayPal order and finalizes the payment.
   }
   ```
 
-- `500 Internal Server Error` returned if the capture fails.

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -26,7 +26,6 @@ Generates and returns a browser-safe client token for initializing the PayPal Ja
   }
   ```
 
-- `500 Internal Server Error` returned if token generation fails.
 
 ---
 


### PR DESCRIPTION
This update adds comprehensive API documentation to the README.md for the example Node.js server. The new section includes detailed descriptions of each available endpoint, including:

GET /paypal-api/auth/browser-safe-client-token – Retrieve a client token for initializing the PayPal JavaScript SDK.

POST /paypal-api/checkout/orders/create – Create a new PayPal order with sample data.

POST /paypal-api/checkout/orders/{orderId}/capture – Capture an existing PayPal order to finalize the payment.
