### PR TITLE
feat: add support for typed responses with server sdk

### DIFF
--- a/client/one-time-payment/html/src/custom/paymentHandler/app.js
+++ b/client/one-time-payment/html/src/custom/paymentHandler/app.js
@@ -83,9 +83,9 @@ async function getBrowserSafeClientToken() {
       "Content-Type": "application/json",
     },
   });
-  const { access_token } = await response.json();
+  const { accessToken } = await response.json();
 
-  return access_token;
+  return accessToken;
 }
 
 async function createOrder() {
@@ -98,9 +98,9 @@ async function createOrder() {
       },
     },
   );
-  const orderData = await response.json();
+  const { id } = await response.json();
 
-  return { orderId: orderData.id };
+  return { orderId: id };
 }
 
 async function captureOrder({ orderId }) {

--- a/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/integration.js
+++ b/client/one-time-payment/html/src/custom/sandboxedIframe/src/paypal-iframe/integration.js
@@ -156,9 +156,9 @@ async function getBrowserSafeClientToken() {
       "Content-Type": "application/json",
     },
   });
-  const { access_token } = await response.json();
+  const { accessToken } = await response.json();
 
-  return access_token;
+  return accessToken;
 }
 
 async function createOrder() {
@@ -171,9 +171,9 @@ async function createOrder() {
       },
     },
   );
-  const orderData = await response.json();
+  const { id } = await response.json();
 
-  return { orderId: orderData.id };
+  return { orderId: id };
 }
 
 async function captureOrder({ orderId }) {

--- a/client/one-time-payment/html/src/recommended/app.js
+++ b/client/one-time-payment/html/src/recommended/app.js
@@ -85,9 +85,9 @@ async function getBrowserSafeClientToken() {
       "Content-Type": "application/json",
     },
   });
-  const { access_token } = await response.json();
+  const { accessToken } = await response.json();
 
-  return access_token;
+  return accessToken;
 }
 
 async function createOrder() {
@@ -100,9 +100,9 @@ async function createOrder() {
       },
     },
   );
-  const orderData = await response.json();
+  const { id } = await response.json();
 
-  return { orderId: orderData.id };
+  return { orderId: id };
 }
 
 async function captureOrder({ orderId }) {

--- a/client/one-time-payment/react/src/utils.ts
+++ b/client/one-time-payment/react/src/utils.ts
@@ -6,9 +6,9 @@ export const getBrowserSafeClientToken = async () => {
         "Content-Type": "application/json",
       },
     });
-    const { access_token } = await response.json();
+    const { accessToken } = await response.json();
 
-    return access_token;
+    return accessToken;
   }
 };
 
@@ -22,8 +22,8 @@ export const createOrder = async () => {
       },
     },
   );
-  const orderData = await response.json();
-  return { orderId: orderData.id };
+  const { id } = await response.json();
+  return { orderId: id };
 };
 
 export const captureOrder = async ({ orderId }: { orderId: string }) => {

--- a/client/save-payment/html/src/recommended/app.js
+++ b/client/save-payment/html/src/recommended/app.js
@@ -58,9 +58,9 @@ async function getBrowserSafeClientToken() {
       "Content-Type": "application/json",
     },
   });
-  const { access_token } = await response.json();
+  const { accessToken } = await response.json();
 
-  return access_token;
+  return accessToken;
 }
 
 async function createSetupToken() {
@@ -70,7 +70,7 @@ async function createSetupToken() {
       "Content-Type": "application/json",
     },
   });
-  const setupTokenData = await response.json();
+  const { id } = await response.json();
 
-  return { setupToken: setupTokenData.id };
+  return { setupToken: id };
 }

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -22,8 +22,8 @@ Generates and returns a browser-safe client token for initializing the PayPal Ja
 
   ```json
   {
-    "access_token": "abc123...",
-    "expires_in": "900" // TTL in seconds,
+    "accessToken": "abc123...",
+    "expiresIn": "900" // TTL in seconds,
     // additional metadata
   }
   ```

--- a/server/node/src/paypalServerSdk.ts
+++ b/server/node/src/paypalServerSdk.ts
@@ -20,6 +20,7 @@ import {
 
 import type {
   OAuthProviderError,
+  OAuthToken,
   OrderRequest,
 } from "@paypal/paypal-server-sdk";
 
@@ -71,8 +72,26 @@ export async function getBrowserSafeClientToken() {
         { response_type: "client_token" },
       );
 
+    // the OAuthToken type is too general
+    // this interface is specific to the "client_token" response type
+    interface ClientToken {
+      accessToken: string;
+      expiresIn: number;
+      scope: string;
+      tokenType: string;
+    }
+
+    const { accessToken, expiresIn, scope, tokenType } = result;
+    const transformedResult: ClientToken = {
+      accessToken,
+      // convert BigInt value to a Number
+      expiresIn: Number(expiresIn),
+      scope: String(scope),
+      tokenType,
+    };
+
     return {
-      jsonResponse: result,
+      jsonResponse: transformedResult,
       httpStatusCode: statusCode,
     };
   } catch (error) {

--- a/server/node/src/paypalServerSdk.ts
+++ b/server/node/src/paypalServerSdk.ts
@@ -72,7 +72,7 @@ export async function getBrowserSafeClientToken() {
         { response_type: "client_token" },
       );
 
-    // the OAuthToken type is too general
+    // the OAuthToken interface is too general
     // this interface is specific to the "client_token" response type
     interface ClientToken {
       accessToken: string;

--- a/server/node/src/paypalServerSdk.ts
+++ b/server/node/src/paypalServerSdk.ts
@@ -8,6 +8,7 @@ import {
   ApiError,
   CheckoutPaymentIntent,
   Client,
+  CustomError,
   Environment,
   LogLevel,
   OAuthAuthorizationController,
@@ -18,8 +19,8 @@ import {
 } from "@paypal/paypal-server-sdk";
 
 import type {
+  OAuthProviderError,
   OrderRequest,
-  VaultTokenRequest,
 } from "@paypal/paypal-server-sdk";
 
 /* ######################################################################
@@ -64,23 +65,25 @@ export async function getBrowserSafeClientToken() {
       `${PAYPAL_SANDBOX_CLIENT_ID}:${PAYPAL_SANDBOX_CLIENT_SECRET}`,
     ).toString("base64");
 
-    const { body, statusCode } =
+    const { result, statusCode } =
       await oAuthAuthorizationController.requestToken(
-        {
-          authorization: `Basic ${auth}`,
-        },
+        { authorization: `Basic ${auth}` },
         { response_type: "client_token" },
       );
 
     return {
-      jsonResponse: JSON.parse(String(body)),
+      jsonResponse: result,
       httpStatusCode: statusCode,
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      const { statusCode, body } = error;
+      const { result, statusCode } = error;
+      type OAuthError = {
+        error: OAuthProviderError;
+        error_description?: string;
+      };
       return {
-        jsonResponse: JSON.parse(String(body)),
+        jsonResponse: result as OAuthError,
         httpStatusCode: statusCode,
       };
     } else {
@@ -95,20 +98,20 @@ export async function getBrowserSafeClientToken() {
 
 export async function createOrder(orderRequestBody: OrderRequest) {
   try {
-    const { body, statusCode } = await ordersController.createOrder({
+    const { result, statusCode } = await ordersController.createOrder({
       body: orderRequestBody,
       prefer: "return=minimal",
     });
 
     return {
-      jsonResponse: JSON.parse(String(body)),
+      jsonResponse: result,
       httpStatusCode: statusCode,
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      const { statusCode, body } = error;
+      const { result, statusCode } = error;
       return {
-        jsonResponse: JSON.parse(String(body)),
+        jsonResponse: result as CustomError,
         httpStatusCode: statusCode,
       };
     } else {
@@ -134,20 +137,20 @@ export async function createOrderWithSampleData() {
 
 export async function captureOrder(orderId: string) {
   try {
-    const { body, statusCode } = await ordersController.captureOrder({
+    const { result, statusCode } = await ordersController.captureOrder({
       id: orderId,
       prefer: "return=minimal",
     });
 
     return {
-      jsonResponse: JSON.parse(String(body)),
+      jsonResponse: result,
       httpStatusCode: statusCode,
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      const { statusCode, body } = error;
+      const { result, statusCode } = error;
       return {
-        jsonResponse: JSON.parse(String(body)),
+        jsonResponse: result as CustomError,
         httpStatusCode: statusCode,
       };
     } else {
@@ -158,7 +161,7 @@ export async function captureOrder(orderId: string) {
 
 export async function createSetupToken() {
   try {
-    const { body, statusCode } = await vaultController.createSetupToken({
+    const { result, statusCode } = await vaultController.createSetupToken({
       paypalRequestId: Date.now().toString(),
       body: {
         paymentSource: {
@@ -175,15 +178,15 @@ export async function createSetupToken() {
     });
 
     return {
-      jsonResponse: JSON.parse(String(body)),
+      jsonResponse: result,
       httpStatusCode: statusCode,
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      const { statusCode, body } = error;
+      const { result, statusCode } = error;
 
       return {
-        jsonResponse: JSON.parse(String(body)),
+        jsonResponse: result as CustomError,
         httpStatusCode: statusCode,
       };
     } else {

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -13,6 +13,14 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// @ts-ignore - BigInt.prototype.toJSON() exists.
+// The paypal-server-sdk casts numbers to BigInt values (ex: { expiresIn: 900n }).
+// BitInt values must be cast to numbers to work with JSON.stringify() which is used by Express.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/BigInt_not_serializable
+BigInt.prototype.toJSON = function () {
+  return Number(this);
+};
+
 /* ######################################################################
  * API Endpoints for the client-side JavaScript PayPal Integration code
  * ###################################################################### */

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -13,14 +13,6 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-// @ts-ignore - BigInt.prototype.toJSON() exists.
-// The paypal-server-sdk casts numbers to BigInt values (ex: { expiresIn: 900n }).
-// BitInt values must be cast to numbers to work with JSON.stringify() which is used by Express.
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/BigInt_not_serializable
-BigInt.prototype.toJSON = function () {
-  return Number(this);
-};
-
 /* ######################################################################
  * API Endpoints for the client-side JavaScript PayPal Integration code
  * ###################################################################### */


### PR DESCRIPTION
This PR updates the server code to stop doing `JSON.parse(body)` with the server-sdk and instead leverage the parsed and typed `result` option.

This provides a couple benefits:
- the `result` keys in the object are converted from snake_case to camelCase
- the `result` response is typed. Ex:
```ts
  // jsonResponse is typed as Order | CustomError
  const { jsonResponse, httpStatusCode } = await createOrderWithSampleData();
```