### PR TITLE
fix: update eligibility param name to currencyCode

### DIFF
--- a/client/oneTimePayment/html/src/recommended/app.js
+++ b/client/oneTimePayment/html/src/recommended/app.js
@@ -8,7 +8,7 @@ async function onPayPalLoaded() {
     });
 
     const paymentMethods = await sdkInstance.findEligibleMethods({
-      currency: "USD",
+      currencyCode: "USD",
     });
 
     if (paymentMethods.isEligible("paypal")) {

--- a/client/savePayment/html/src/recommended/app.js
+++ b/client/savePayment/html/src/recommended/app.js
@@ -8,7 +8,7 @@ async function onPayPalLoaded() {
     });
 
     const paymentMethods = await sdkInstance.findEligibleMethods({
-      currency: "USD",
+      currencyCode: "USD",
     });
 
     if (paymentMethods.isEligible("paypal")) {


### PR DESCRIPTION
The `findEligibleMethods()` method expects the param to be named `currencyCode`, not `currency`.