### PR TITLE
Add Payment Token functionality to Save Payment flow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,9 @@ jobs:
           find . -name package.json -maxdepth 10 -type f -not -path "*/node_modules/*" | while read -r file; do
             directory=$(dirname "$file")
             echo "::group:: $directory"
-            cd "$directory" && npm install && cd -
+            cd "$directory" 
+            npm install || exit 1
+            cd -
             echo "::endgroup::"
           done
 
@@ -48,6 +50,8 @@ jobs:
           find . -name package.json -maxdepth 10 -type f -not -path "*/node_modules/*" | while read -r file; do
             directory=$(dirname "$file")
             echo "::group:: $directory"
-            cd "$directory" && npm run lint && cd -
+            cd "$directory" 
+            npm run lint || exit 1
+            cd -
             echo "::endgroup::"
           done

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -37,7 +37,9 @@ jobs:
           find . -name package.json -maxdepth 10 -type f -not -path "*/node_modules/*" | while read -r file; do
             directory=$(dirname "$file")
             echo "::group:: $directory"
-            cd "$directory" && npm run format:check && cd -
+            cd "$directory" 
+            npm run format:check || exit 1
+            cd -
             echo "::endgroup::"
           done
 

--- a/client/savePayment/html/src/recommended/app.js
+++ b/client/savePayment/html/src/recommended/app.js
@@ -23,6 +23,10 @@ async function onPayPalLoaded() {
 const paymentSessionOptions = {
   async onApprove(data) {
     console.log("onApprove", data);
+    const createPaymentTokenResponse = await createPaymentToken(
+      data.vaultSetupToken,
+    );
+    console.log(createPaymentTokenResponse);
   },
   onCancel(data) {
     console.log("onCancel", data);
@@ -65,7 +69,7 @@ async function getBrowserSafeClientToken() {
 }
 
 async function createSetupToken() {
-  const response = await fetch("/paypal-api/checkout/setup-token/create", {
+  const response = await fetch("/paypal-api/vault/setup-token/create", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -74,4 +78,17 @@ async function createSetupToken() {
   const { id } = await response.json();
 
   return { setupToken: id };
+}
+
+async function createPaymentToken(vaultSetupToken) {
+  const response = await fetch("/paypal-api/vault/payment-token/create", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ vaultSetupToken }),
+  });
+  const data = await response.json();
+
+  return data;
 }

--- a/client/savePayment/html/src/recommended/app.js
+++ b/client/savePayment/html/src/recommended/app.js
@@ -26,7 +26,7 @@ const paymentSessionOptions = {
     const createPaymentTokenResponse = await createPaymentToken(
       data.vaultSetupToken,
     );
-    console.log(createPaymentTokenResponse);
+    console.log("Create payment token response: ", createPaymentTokenResponse);
   },
   onCancel(data) {
     console.log("onCancel", data);

--- a/client/savePayment/html/src/recommended/index.html
+++ b/client/savePayment/html/src/recommended/index.html
@@ -17,7 +17,7 @@
     <h1>Save Payment Recommended Integration</h1>
 
     <div class="buttons-container">
-      <paypal-button id="paypal-button" type="pay" hidden></paypal-button>
+      <paypal-button id="paypal-button" hidden></paypal-button>
     </div>
     <script src="app.js"></script>
 

--- a/server/node/src/paypalServerSdk.ts
+++ b/server/node/src/paypalServerSdk.ts
@@ -228,11 +228,13 @@ export async function createSetupTokenWithSampleDataForPayPal() {
   return createSetupToken(defaultSetupTokenRequestBody, Date.now().toString());
 }
 
-
-export async function createPaymentToken(vaultSetupToken: string, paypalRequestId?: string) {
+export async function createPaymentToken(
+  vaultSetupToken: string,
+  paypalRequestId?: string,
+) {
   try {
-    const { body, statusCode } = await vaultController.createPaymentToken({
-      paypalRequestId: Date.now().toString(),
+    const { result, statusCode } = await vaultController.createPaymentToken({
+      paypalRequestId: paypalRequestId ?? Date.now().toString(),
       body: {
         paymentSource: {
           token: {
@@ -244,15 +246,15 @@ export async function createPaymentToken(vaultSetupToken: string, paypalRequestI
     });
 
     return {
-      jsonResponse: JSON.parse(String(body)),
+      jsonResponse: result,
       httpStatusCode: statusCode,
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      const { statusCode, body } = error;
+      const { result, statusCode } = error;
 
       return {
-        jsonResponse: JSON.parse(String(body)),
+        jsonResponse: result as CustomError,
         httpStatusCode: statusCode,
       };
     } else {

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -90,10 +90,21 @@ app.post(
 
       if (paymentTokenResponse.id) {
         await savePaymentTokenToDatabase(paymentTokenResponse);
-        res.status(httpStatusCode).json({ status: "SUCCESS", description: "Payment token saved to database for future transactions" });
+        res
+          .status(httpStatusCode)
+          .json({
+            status: "SUCCESS",
+            description:
+              "Payment token saved to database for future transactions",
+          });
       } else {
-        res.status(httpStatusCode).json({ status: "ERROR", description: "Failed to create payment token" });
-      } 
+        res
+          .status(httpStatusCode)
+          .json({
+            status: "ERROR",
+            description: "Failed to create payment token",
+          });
+      }
     } catch (error) {
       console.error("Failed to create payment token:", error);
       res.status(500).json({ error: "Failed to create payment token." });
@@ -101,7 +112,9 @@ app.post(
   },
 );
 
-async function savePaymentTokenToDatabase(paymentTokenResponse: PaymentTokenResponse) {
+async function savePaymentTokenToDatabase(
+  paymentTokenResponse: PaymentTokenResponse,
+) {
   // example function to teach saving the paymentToken to a database
   // to be used for future transactions
   return Promise.resolve();

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -89,6 +89,10 @@ app.post(
       const paymentTokenResponse = jsonResponse as PaymentTokenResponse;
 
       if (paymentTokenResponse.id) {
+        // This payment token id is a long-lived value for making
+        // future payments when the buyer is not present.
+        // PayPal recommends storing this value in your database
+        // and NOT returning it back to the browser.
         await savePaymentTokenToDatabase(paymentTokenResponse);
         res.status(httpStatusCode).json({
           status: "SUCCESS",

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -90,20 +90,16 @@ app.post(
 
       if (paymentTokenResponse.id) {
         await savePaymentTokenToDatabase(paymentTokenResponse);
-        res
-          .status(httpStatusCode)
-          .json({
-            status: "SUCCESS",
-            description:
-              "Payment token saved to database for future transactions",
-          });
+        res.status(httpStatusCode).json({
+          status: "SUCCESS",
+          description:
+            "Payment token saved to database for future transactions",
+        });
       } else {
-        res
-          .status(httpStatusCode)
-          .json({
-            status: "ERROR",
-            description: "Failed to create payment token",
-          });
+        res.status(httpStatusCode).json({
+          status: "ERROR",
+          description: "Failed to create payment token",
+        });
       }
     } catch (error) {
       console.error("Failed to create payment token:", error);

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -5,7 +5,7 @@ import {
   getBrowserSafeClientToken,
   createOrderWithSampleData,
   captureOrder,
-  createSetupToken,
+  createSetupTokenWithSampleDataForPayPal,
 } from "./paypalServerSdk";
 
 const app = express();
@@ -65,7 +65,8 @@ app.post(
   "/paypal-api/checkout/setup-token/create",
   async (_req: Request, res: Response) => {
     try {
-      const { jsonResponse, httpStatusCode } = await createSetupToken();
+      const { jsonResponse, httpStatusCode } =
+        await createSetupTokenWithSampleDataForPayPal();
       res.status(httpStatusCode).json(jsonResponse);
     } catch (error) {
       console.error("Failed to create setup token:", error);


### PR DESCRIPTION
This PR updates the SavePayment flow to add logic to the onApprove() callback to upgrade the vaultSetupToken to a paymentToken that can be used for future transactions. Now our Save Payment demo aligns with this v5 doc: https://developer.paypal.com/docs/checkout/save-payment-methods/purchase-later/js-sdk/paypal/