### PR TITLE
feat: bump prettier version

### DIFF
--- a/client/components/fastlane/html/package.json
+++ b/client/components/fastlane/html/package.json
@@ -13,7 +13,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "vite": "^6.2.0"
   }
 }

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/package.json
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/package.json
@@ -12,7 +12,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "prettier": "^3.5.3"
+    "prettier": "^3.6.2"
   },
   "dependencies": {
     "concurrently": "^9.1.2",

--- a/client/components/paypalPayments/savePayment/html/package.json
+++ b/client/components/paypalPayments/savePayment/html/package.json
@@ -13,7 +13,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "vite": "^6.2.0"
   }
 }

--- a/client/components/upstreamMessages/html/package.json
+++ b/client/components/upstreamMessages/html/package.json
@@ -13,7 +13,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "vite": "^6.2.0"
   }
 }

--- a/client/components/venmoPayments/oneTimePayment/html/package.json
+++ b/client/components/venmoPayments/oneTimePayment/html/package.json
@@ -13,7 +13,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "vite": "^6.2.0"
   }
 }

--- a/client/prebuiltPages/react/oneTimePayment/package.json
+++ b/client/prebuiltPages/react/oneTimePayment/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0"

--- a/server/node/package.json
+++ b/server/node/package.json
@@ -26,7 +26,7 @@
     "@types/express": "^5.0.1",
     "@types/node": "^22.14.0",
     "@types/semver": "^7.7.0",
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "semver": "^7.7.1",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3"


### PR DESCRIPTION
In CI, GitHub Actions will throw `prettier` formatting issues for various `README.md` files, but not locally, unless you're using `prettier` version `3.6.2`. Thusly, this PR bumps all versions of `prettier` to `3.6.2`.