### PR TITLE
A PayPal Button Demo

### DIFF
--- a/client/prebuiltPages/react/oneTimePayment/src/hooks/useCreatePayPalOneTimePaymentSession.tsx
+++ b/client/prebuiltPages/react/oneTimePayment/src/hooks/useCreatePayPalOneTimePaymentSession.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import {
+  PaymentSessionOptions,
+  SdkInstance,
+  SessionOutput,
+} from "../types/paypal";
+
+export type UseCreatePayPalOneTimePaymentSessionOptions =
+  PaymentSessionOptions & {
+    sdkInstance: SdkInstance | null;
+  };
+
+export const useCreatePayPalOneTimePaymentSession = ({
+  sdkInstance,
+  onApprove,
+  onCancel,
+  onError,
+}: UseCreatePayPalOneTimePaymentSessionOptions) => {
+  const [session, setSession] = useState<SessionOutput | null>(null);
+
+  useEffect(() => {
+    if (!sdkInstance) {
+      setSession(null);
+      // throw some type of error here
+      return;
+    }
+
+    // Cleanup previous session if it exists
+    if (session) {
+      session.destroy();
+    }
+
+    // Create new session
+    const newSession = sdkInstance.createPayPalOneTimePaymentSession({
+      onApprove,
+      onCancel,
+      onError,
+    });
+
+    setSession(newSession);
+
+    // Cleanup on unmount or dependency change
+    return () => {
+      if (session) {
+        session.destroy();
+      }
+    };
+  }, [sdkInstance, onApprove, onCancel, onError]);
+
+  return session;
+};


### PR DESCRIPTION
This PR demonstrates the usage of a custom React hook to create a One Time Payment session for the PayPal Button.

Some other features of note:
- Moves merchant callbacks to the button for sake of ease. 
- Merchant callbacks leverage `useCallback` in order to prevent re-render issues.