### PR TITLE
feat: rename `onPayPalLoaded` to `onPayPalWebSdkLoaded`

### DIFF
--- a/client/components/fastlane/html/src/fastlaneSdkComponent.js
+++ b/client/components/fastlane/html/src/fastlaneSdkComponent.js
@@ -1,5 +1,5 @@
 let fastlane;
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   const clientToken = await getBrowserSafeClientToken();
 
   const sdkInstance = await window.paypal.createInstance({

--- a/client/components/fastlane/html/src/index.html
+++ b/client/components/fastlane/html/src/index.html
@@ -42,7 +42,7 @@
     <script src="fastlane.js"></script>
     <script
       async
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
     ></script>
   </body>

--- a/client/components/paypalMessages/html/src/advanced/app.js
+++ b/client/components/paypalMessages/html/src/advanced/app.js
@@ -1,4 +1,4 @@
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   try {
     const clientToken = await getBrowserSafeClientToken();
     const sdkInstance = await window.paypal.createInstance({

--- a/client/components/paypalMessages/html/src/advanced/index.html
+++ b/client/components/paypalMessages/html/src/advanced/index.html
@@ -18,7 +18,7 @@
     <script
       async
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
     ></script>
   </body>
 </html>

--- a/client/components/paypalMessages/html/src/recommended/app.js
+++ b/client/components/paypalMessages/html/src/recommended/app.js
@@ -1,4 +1,4 @@
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   try {
     const clientToken = await getBrowserSafeClientToken();
     const sdkInstance = await window.paypal.createInstance({

--- a/client/components/paypalMessages/html/src/recommended/index.html
+++ b/client/components/paypalMessages/html/src/recommended/index.html
@@ -33,7 +33,7 @@
     <script
       async
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
     ></script>
   </body>
 </html>

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/paymentHandler/app.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/paymentHandler/app.js
@@ -1,4 +1,4 @@
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   try {
     const clientToken = await getBrowserSafeClientToken();
     const sdkInstance = await window.paypal.createInstance({

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/paymentHandler/index.html
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/paymentHandler/index.html
@@ -14,7 +14,7 @@
     <script
       async
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
     ></script>
   </body>
 </html>

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/redirect/app.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/redirect/app.js
@@ -1,4 +1,4 @@
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   try {
     const clientToken = await getBrowserSafeClientToken();
     const sdkInstance = await window.paypal.createInstance({

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/redirect/index.html
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/redirect/index.html
@@ -18,7 +18,7 @@
     <script src="app.js"></script>
     <script
       async
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
     ></script>
   </body>

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/index.html
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/index.html
@@ -89,7 +89,7 @@
     <script
       async
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
     ></script>
   </body>
 </html>

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/integration.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/integration.js
@@ -124,7 +124,7 @@ async function setupPayPalButton(sdkInstance) {
   });
 }
 
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   if (window.setupComplete) {
     return;
   }

--- a/client/components/paypalPayments/oneTimePayment/html/src/recommended/app.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/recommended/app.js
@@ -1,4 +1,4 @@
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   try {
     const clientToken = await getBrowserSafeClientToken();
     const sdkInstance = await window.paypal.createInstance({

--- a/client/components/paypalPayments/oneTimePayment/html/src/recommended/index.html
+++ b/client/components/paypalPayments/oneTimePayment/html/src/recommended/index.html
@@ -31,7 +31,7 @@
     <script
       async
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
     ></script>
   </body>
 </html>

--- a/client/components/paypalPayments/savePayment/html/src/app.js
+++ b/client/components/paypalPayments/savePayment/html/src/app.js
@@ -1,4 +1,4 @@
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   try {
     const clientToken = await getBrowserSafeClientToken();
     const sdkInstance = await window.paypal.createInstance({

--- a/client/components/paypalPayments/savePayment/html/src/index.html
+++ b/client/components/paypalPayments/savePayment/html/src/index.html
@@ -24,7 +24,7 @@
     <script
       async
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
     ></script>
   </body>
 </html>

--- a/client/components/venmoPayments/oneTimePayment/html/src/app.js
+++ b/client/components/venmoPayments/oneTimePayment/html/src/app.js
@@ -1,4 +1,4 @@
-async function onPayPalLoaded() {
+async function onPayPalWebSdkLoaded() {
   try {
     const clientToken = await getBrowserSafeClientToken();
     const sdkInstance = await window.paypal.createInstance({

--- a/client/components/venmoPayments/oneTimePayment/html/src/index.html
+++ b/client/components/venmoPayments/oneTimePayment/html/src/index.html
@@ -23,7 +23,7 @@
     <script
       async
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
-      onload="onPayPalLoaded()"
+      onload="onPayPalWebSdkLoaded()"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
This PR renames `onPayPalLoaded` to `onPayPalWebSdkLoaded` per [this convo](https://github.com/paypal-examples/v6-web-sdk-sample-integration/pull/62#discussion_r2220098271).