### PR TITLE
feat: add JavaScript SDK packages for PayPal v6 Web SDK

### DIFF
--- a/README_SDK.md
+++ b/README_SDK.md
@@ -1,0 +1,400 @@
+# PayPal v6 Web SDK JavaScript Packages
+
+## Overview
+
+This document describes the JavaScript SDK packages created for PayPal's v6 Web SDK. These packages provide a modern, TypeScript-first wrapper around PayPal's payment SDK, making it easier to integrate PayPal payments into JavaScript applications.
+
+## Architecture
+
+The SDK is organized as a monorepo using npm workspaces, with the following package structure:
+
+```
+packages/
+├── types/          # Shared TypeScript definitions
+├── core/           # Core SDK wrapper and utilities
+├── react/          # React hooks and components
+└── vue/            # Vue composables (structure ready)
+```
+
+## Packages Created
+
+### 1. @paypal-v6/types
+
+**Purpose**: Provides comprehensive TypeScript type definitions for the entire SDK ecosystem.
+
+**Key Features**:
+- Complete type definitions for all PayPal payment methods
+- Interfaces for SDK initialization and configuration
+- Order creation and capture types
+- Payment session callbacks and events
+- Error codes and custom error classes
+- Component configurations for buttons and messages
+
+**Main Type Categories**:
+- `sdk.ts` - Core SDK interfaces (SdkInstance, CreateInstanceOptions, EligiblePaymentMethods)
+- `payment-methods.ts` - Payment method enums and configurations (PayPal, Venmo, Google Pay, Apple Pay, etc.)
+- `orders.ts` - Order types (CreateOrderRequest, Order, CaptureOrderResponse, Amount, PurchaseUnit)
+- `callbacks.ts` - Event handlers (OnApproveData, OnCancelData, OnErrorData, PaymentSessionOptions)
+- `components.ts` - UI component types (ButtonStyle, MessagesConfig, FastlaneConfig)
+- `errors.ts` - Error handling (PayPalSdkError, ErrorCode, RetryConfig)
+- `config.ts` - SDK configuration (SdkConfig, Environment, LoggerConfig)
+
+### 2. @paypal-v6/core
+
+**Purpose**: Core SDK wrapper that handles script loading, initialization, and payment session management.
+
+**Key Components**:
+
+#### SDK Loader (`loader.ts`)
+- Dynamically injects PayPal SDK script into the page
+- Configurable URL builder for different environments (sandbox/production)
+- Singleton pattern to prevent multiple script loads
+- Promise-based loading with timeout support
+- CSP nonce support for security
+
+#### SDK Class (`sdk.ts`)
+- Main SDK wrapper with singleton pattern
+- Handles SDK initialization with client tokens
+- Manages payment sessions lifecycle
+- Provides methods for creating payment sessions for each payment method
+- Built-in browser compatibility checking
+- Event-driven architecture for SDK lifecycle
+
+#### Session Manager (`sessions.ts`)
+- Wrapper classes for payment sessions
+- Specialized handlers for Google Pay and Apple Pay
+- Session lifecycle management (create, start, cancel, destroy)
+- Event emission for payment lifecycle events
+
+#### Event Emitter (`events.ts`)
+- Custom event system for SDK events
+- Support for one-time listeners
+- Event types: ready, loaded, error, payment_approved, payment_cancelled, session_started, session_ended
+
+#### Utilities (`utils.ts`)
+- Retry logic with exponential backoff
+- Logger implementation with configurable levels
+- Validation helpers (email, currency, amount)
+- Browser and device detection
+- Deep merge for configuration objects
+- PayPal error parsing
+
+**Key Features**:
+- Automatic script loading and initialization
+- Promise-based API
+- Comprehensive error handling with retry logic
+- TypeScript-safe method signatures
+- Event-driven architecture
+- Session lifecycle management
+
+### 3. @paypal-v6/react
+
+**Purpose**: React-specific SDK implementation with hooks and components.
+
+**Components Created**:
+
+#### Context & Provider (`PayPalSDKContext.tsx`)
+- `PayPalSDKProvider` - Wraps application with SDK context
+- Manages SDK initialization and state
+- Provides loading and error states
+- Supports deferred loading
+- Automatic eligible payment methods detection
+
+#### Payment Button Components
+- `PayPalButton.tsx` - PayPal payment button with full customization
+- `VenmoButton.tsx` - Venmo payment button
+- `PayLaterButton.tsx` - Pay Later button
+- `PayPalCreditButton.tsx` - PayPal Credit button
+- `GooglePayButton.tsx` - Google Pay integration with native button
+- `ApplePayButton.tsx` - Apple Pay integration with native button
+- `PayPalMessages.tsx` - Pay Later messaging component
+
+#### Custom Hooks
+- `usePayPalSDK()` - Access SDK instance and state
+- `usePaymentSession()` - Manage payment sessions for any payment method
+- `usePayPalSession()` - Specialized hook for PayPal payments
+- `useEligibleMethods()` - Check payment method eligibility
+- `useGooglePay()` - Google Pay specific integration
+- `useApplePay()` - Apple Pay specific integration
+
+#### Utility Components
+- `PaymentMethodSelector.tsx` - Renders multiple payment buttons with eligibility checking
+- `PaymentModal.tsx` - Modal component for payment flows
+- `ErrorBoundary.tsx` - React error boundary for catching payment errors
+
+**Key Features**:
+- Full React hooks integration
+- Server-side rendering (SSR) compatible
+- Automatic cleanup on unmount
+- TypeScript support with proper typing
+- Error boundaries for robust error handling
+- Flexible payment method selection
+
+### 4. @paypal-v6/vue (Structure Ready)
+
+**Purpose**: Vue 3 composables and components for PayPal integration.
+
+**Status**: Package structure and configuration are ready. Implementation follows the same patterns as the React package but uses Vue 3 Composition API.
+
+## Implementation Highlights
+
+### 1. Modern JavaScript Patterns
+- ES6+ modules with tree-shaking support
+- Promise-based APIs throughout
+- Async/await for cleaner asynchronous code
+- Event-driven architecture
+
+### 2. TypeScript First
+- Complete type coverage
+- Strict type checking enabled
+- Type inference for better developer experience
+- Discriminated unions for payment methods
+
+### 3. Error Handling
+- Custom error class (`PayPalSdkError`) with error codes
+- Retry logic with exponential backoff
+- Comprehensive error recovery strategies
+- Debug IDs for PayPal support
+
+### 4. Developer Experience
+- IntelliSense support in IDEs
+- Clear API documentation through types
+- Consistent naming conventions
+- Modular architecture for tree-shaking
+
+### 5. Security Features
+- CSP nonce support
+- Browser compatibility checking
+- Secure token handling
+- No sensitive data in client code
+
+## Build Configuration
+
+### Tooling
+- **TypeScript** - Type safety and modern JavaScript
+- **tsup** - Fast bundler with zero config
+- **npm workspaces** - Monorepo management
+- **Prettier** - Code formatting
+
+### Build Output
+Each package produces:
+- CommonJS build (`dist/index.js`)
+- ESM build (`dist/index.esm.js`)
+- TypeScript declarations (`dist/index.d.ts`)
+- Source maps for debugging
+
+## Usage Examples
+
+### Basic React Integration
+
+```tsx
+import { PayPalSDKProvider, PayPalButton } from '@paypal-v6/react';
+
+function App() {
+  return (
+    <PayPalSDKProvider 
+      config={{
+        clientToken: 'your-client-token',
+        environment: 'sandbox',
+        components: ['paypal-payments', 'venmo-payments']
+      }}
+    >
+      <CheckoutPage />
+    </PayPalSDKProvider>
+  );
+}
+
+function CheckoutPage() {
+  const createOrder = async () => {
+    const response = await fetch('/api/orders', { method: 'POST' });
+    const { id } = await response.json();
+    return { orderId: id };
+  };
+
+  return (
+    <PayPalButton
+      createOrder={createOrder}
+      sessionOptions={{
+        onApprove: async (data) => {
+          console.log('Payment approved:', data.orderId);
+        },
+        onError: (error) => {
+          console.error('Payment failed:', error);
+        }
+      }}
+    />
+  );
+}
+```
+
+### Core SDK Direct Usage
+
+```javascript
+import { PayPalSDK } from '@paypal-v6/core';
+
+// Initialize SDK
+const sdk = PayPalSDK.getInstance({
+  clientToken: 'your-client-token',
+  environment: 'sandbox',
+  components: ['paypal-payments']
+});
+
+// Wait for SDK to be ready
+await sdk.initialize();
+
+// Check eligible payment methods
+const eligibleMethods = await sdk.findEligibleMethods({
+  currencyCode: 'USD'
+});
+
+if (eligibleMethods.isEligible('paypal')) {
+  // Create PayPal session
+  const session = sdk.createPayPalSession({
+    onApprove: async (data) => {
+      console.log('Payment approved:', data.orderId);
+    }
+  });
+  
+  // Start payment
+  await session.start(
+    { presentationMode: 'auto' },
+    createOrder()
+  );
+}
+```
+
+## Installation
+
+### Install Dependencies
+```bash
+# Install all dependencies for all packages
+npm install
+
+# Build all packages
+npm run build
+
+# Run tests (when implemented)
+npm test
+```
+
+### Using the Packages
+
+For development in this repository:
+```bash
+# The packages are linked via npm workspaces
+# Any changes will be reflected immediately in development
+npm run dev
+```
+
+For external projects (after publishing):
+```bash
+# Install core package
+npm install @paypal-v6/core @paypal-v6/types
+
+# For React projects
+npm install @paypal-v6/react
+
+# For Vue projects
+npm install @paypal-v6/vue
+```
+
+## Package Features Comparison
+
+| Feature | Core | React | Vue |
+|---------|------|-------|-----|
+| SDK Loading | ✅ | Via Core | Via Core |
+| TypeScript | ✅ | ✅ | ✅ |
+| Payment Sessions | ✅ | ✅ | Planned |
+| Event Emitter | ✅ | Via Hooks | Planned |
+| Error Handling | ✅ | ✅ | Planned |
+| Button Components | ❌ | ✅ | Planned |
+| Hooks/Composables | ❌ | ✅ | Planned |
+| SSR Support | ✅ | ✅ | Planned |
+
+## Development Workflow
+
+1. **Make Changes**: Edit files in `packages/*/src`
+2. **Build**: Run `npm run build` to compile all packages
+3. **Test**: Run `npm test` to run tests (when implemented)
+4. **Format**: Run `npm run format` to format code
+
+## Architecture Decisions
+
+### Why Monorepo?
+- Shared dependencies and tooling
+- Atomic commits across packages
+- Easier refactoring and maintenance
+- Single source of truth for types
+
+### Why TypeScript?
+- Type safety prevents runtime errors
+- Better IDE support and IntelliSense
+- Self-documenting code
+- Easier refactoring
+
+### Why Event-Driven?
+- Decoupled architecture
+- Flexible integration points
+- Better debugging capabilities
+- Framework-agnostic core
+
+### Why Singleton Pattern for SDK?
+- Prevents multiple SDK instances
+- Ensures single script load
+- Consistent state management
+- Memory efficient
+
+## Future Enhancements
+
+### Planned Features
+1. **Vue Implementation** - Complete Vue 3 composables
+2. **Angular Package** - Support for Angular applications
+3. **Testing Suite** - Comprehensive unit and integration tests
+4. **Documentation Site** - Interactive documentation with examples
+5. **More Payment Methods** - Support for additional payment methods
+6. **Webhooks Support** - Server-side webhook handlers
+7. **Validation Library** - Advanced order validation
+8. **Debugging Tools** - Development mode with enhanced logging
+
+### Potential Optimizations
+- Code splitting for payment methods
+- Lazy loading of components
+- Performance monitoring hooks
+- A/B testing utilities
+- Analytics integration
+
+## Contributing
+
+### Package Structure
+When adding new features, follow this structure:
+- Types go in `packages/types/src`
+- Core logic goes in `packages/core/src`
+- React components go in `packages/react/src`
+- Keep framework-specific code isolated
+
+### Code Style
+- Use TypeScript for all new code
+- Follow existing naming conventions
+- Add JSDoc comments for public APIs
+- Write self-documenting code
+
+### Testing
+- Unit test utilities and hooks
+- Integration test payment flows
+- E2E test complete checkout process
+- Mock PayPal SDK for testing
+
+## License
+
+This SDK wrapper is provided as-is for integration with PayPal's v6 Web SDK. Ensure you comply with PayPal's terms of service and SDK license agreements.
+
+## Support
+
+For issues related to:
+- **SDK Wrapper**: Create an issue in this repository
+- **PayPal SDK**: Contact PayPal developer support
+- **Integration Help**: Refer to PayPal's official documentation
+
+## Conclusion
+
+This SDK package system provides a modern, type-safe, and developer-friendly way to integrate PayPal's v6 Web SDK into JavaScript applications. The modular architecture allows developers to use only what they need, while the TypeScript definitions ensure a robust development experience.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "paypal-v6-sdk-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "PayPal v6 Web SDK JavaScript packages",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces --if-present",
+    "lint": "npm run lint --workspaces --if-present",
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "clean": "npm run clean --workspaces --if-present"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "typescript": "^5.8.3",
+    "prettier": "^3.6.2"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@paypal-v6/core",
+  "version": "0.1.0",
+  "description": "Core PayPal v6 Web SDK wrapper",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@paypal-v6/types": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "vitest": "^2.1.8",
+    "typescript": "^5.8.3"
+  },
+  "peerDependencies": {},
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,0 +1,119 @@
+import { SdkEventType, SdkEvent, EventListener } from '@paypal-v6/types';
+
+/**
+ * Event emitter for SDK events
+ */
+export class EventEmitter {
+  private events: Map<SdkEventType, Set<EventListener>> = new Map();
+  private onceEvents: Map<SdkEventType, Set<EventListener>> = new Map();
+
+  /**
+   * Add event listener
+   */
+  on(event: SdkEventType, listener: EventListener): void {
+    if (!this.events.has(event)) {
+      this.events.set(event, new Set());
+    }
+    this.events.get(event)!.add(listener);
+  }
+
+  /**
+   * Remove event listener
+   */
+  off(event: SdkEventType, listener: EventListener): void {
+    const listeners = this.events.get(event);
+    if (listeners) {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        this.events.delete(event);
+      }
+    }
+
+    const onceListeners = this.onceEvents.get(event);
+    if (onceListeners) {
+      onceListeners.delete(listener);
+      if (onceListeners.size === 0) {
+        this.onceEvents.delete(event);
+      }
+    }
+  }
+
+  /**
+   * Add one-time event listener
+   */
+  once(event: SdkEventType, listener: EventListener): void {
+    if (!this.onceEvents.has(event)) {
+      this.onceEvents.set(event, new Set());
+    }
+    this.onceEvents.get(event)!.add(listener);
+  }
+
+  /**
+   * Emit an event
+   */
+  emit(event: SdkEventType, payload?: any): void {
+    const sdkEvent: SdkEvent = {
+      type: event,
+      payload,
+      timestamp: Date.now()
+    };
+
+    // Call regular listeners
+    const listeners = this.events.get(event);
+    if (listeners) {
+      listeners.forEach(listener => {
+        try {
+          listener(sdkEvent);
+        } catch (error) {
+          console.error(`Error in event listener for ${event}:`, error);
+        }
+      });
+    }
+
+    // Call one-time listeners
+    const onceListeners = this.onceEvents.get(event);
+    if (onceListeners) {
+      onceListeners.forEach(listener => {
+        try {
+          listener(sdkEvent);
+        } catch (error) {
+          console.error(`Error in once event listener for ${event}:`, error);
+        }
+      });
+      // Clear once listeners after calling
+      this.onceEvents.delete(event);
+    }
+  }
+
+  /**
+   * Remove all listeners for an event
+   */
+  removeAllListeners(event?: SdkEventType): void {
+    if (event) {
+      this.events.delete(event);
+      this.onceEvents.delete(event);
+    } else {
+      this.events.clear();
+      this.onceEvents.clear();
+    }
+  }
+
+  /**
+   * Get listener count for an event
+   */
+  listenerCount(event: SdkEventType): number {
+    const regularCount = this.events.get(event)?.size || 0;
+    const onceCount = this.onceEvents.get(event)?.size || 0;
+    return regularCount + onceCount;
+  }
+
+  /**
+   * Get all event names that have listeners
+   */
+  eventNames(): SdkEventType[] {
+    const names = new Set<SdkEventType>();
+    this.events.forEach((_, key) => names.add(key));
+    this.onceEvents.forEach((_, key) => names.add(key));
+    return Array.from(names);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,6 @@
+export { PayPalSDK } from './sdk';
+export { SdkLoader } from './loader';
+export { EventEmitter } from './events';
+export { PaymentSessionManager } from './sessions';
+export * from './utils';
+export * from '@paypal-v6/types';

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -1,0 +1,309 @@
+import {
+  Environment,
+  SdkConfig,
+  SdkState,
+  ErrorCode,
+  PayPalSdkError,
+  Component
+} from '@paypal-v6/types';
+
+/**
+ * SDK URL builder
+ */
+export class SdkUrlBuilder {
+  private baseUrl: string;
+  private params: URLSearchParams;
+
+  constructor(config: SdkConfig) {
+    const env = config.environment || Environment.SANDBOX;
+    const version = config.version || 'v6';
+    
+    // Build base URL
+    if (config.sdkUrl) {
+      this.baseUrl = config.sdkUrl;
+    } else {
+      const domain = env === Environment.PRODUCTION 
+        ? 'https://www.paypal.com'
+        : 'https://www.sandbox.paypal.com';
+      this.baseUrl = `${domain}/web-sdk/${version}/core`;
+    }
+
+    // Build query parameters
+    this.params = new URLSearchParams();
+    
+    if (config.clientId) {
+      this.params.set('client-id', config.clientId);
+    }
+    
+    if (config.components?.length) {
+      this.params.set('components', config.components.join(','));
+    }
+    
+    if (config.currency) {
+      this.params.set('currency', config.currency);
+    }
+    
+    if (config.locale) {
+      this.params.set('locale', config.locale);
+    }
+    
+    if (config.buyerCountry) {
+      this.params.set('buyer-country', config.buyerCountry);
+    }
+    
+    if (config.debug) {
+      this.params.set('debug', 'true');
+    }
+    
+    if (config.disableFunding?.length) {
+      this.params.set('disable-funding', config.disableFunding.join(','));
+    }
+    
+    if (config.enableFunding?.length) {
+      this.params.set('enable-funding', config.enableFunding.join(','));
+    }
+    
+    if (config.intent) {
+      this.params.set('intent', config.intent);
+    }
+    
+    if (config.commit !== undefined) {
+      this.params.set('commit', String(config.commit));
+    }
+    
+    if (config.vault !== undefined) {
+      this.params.set('vault', typeof config.vault === 'boolean' ? String(config.vault) : 'true');
+    }
+    
+    if (config.merchantId) {
+      this.params.set('merchant-id', config.merchantId);
+    }
+    
+    if (config.partnerAttributionId) {
+      this.params.set('partner-attribution-id', config.partnerAttributionId);
+    }
+    
+    if (config.clientMetadataId) {
+      this.params.set('client-metadata-id', config.clientMetadataId);
+    }
+    
+    if (config.integrationDate) {
+      this.params.set('integration-date', config.integrationDate);
+    }
+    
+    if (config.enable3DS) {
+      this.params.set('enable-3ds', 'true');
+    }
+  }
+
+  /**
+   * Build the complete SDK URL
+   */
+  build(): string {
+    const queryString = this.params.toString();
+    return queryString ? `${this.baseUrl}?${queryString}` : this.baseUrl;
+  }
+}
+
+/**
+ * SDK script loader
+ */
+export class SdkLoader {
+  private static instance: SdkLoader | null = null;
+  private state: SdkState = SdkState.NOT_INITIALIZED;
+  private loadPromise: Promise<void> | null = null;
+  private script: HTMLScriptElement | null = null;
+  private config: SdkConfig | null = null;
+  private loadCallbacks: Array<() => void> = [];
+  private errorCallbacks: Array<(error: Error) => void> = [];
+
+  /**
+   * Get singleton instance
+   */
+  static getInstance(): SdkLoader {
+    if (!SdkLoader.instance) {
+      SdkLoader.instance = new SdkLoader();
+    }
+    return SdkLoader.instance;
+  }
+
+  /**
+   * Private constructor for singleton
+   */
+  private constructor() {}
+
+  /**
+   * Get current state
+   */
+  getState(): SdkState {
+    return this.state;
+  }
+
+  /**
+   * Check if SDK is loaded
+   */
+  isLoaded(): boolean {
+    return this.state === SdkState.READY && typeof window !== 'undefined' && window.paypal?.createInstance !== undefined;
+  }
+
+  /**
+   * Load the PayPal SDK script
+   */
+  async load(config: SdkConfig): Promise<void> {
+    // Return existing promise if already loading
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+
+    // Check if already loaded
+    if (this.isLoaded()) {
+      return Promise.resolve();
+    }
+
+    // Check for existing PayPal script
+    if (typeof window !== 'undefined' && window.paypal?.createInstance) {
+      this.state = SdkState.READY;
+      return Promise.resolve();
+    }
+
+    this.config = config;
+    this.state = SdkState.LOADING;
+
+    this.loadPromise = new Promise<void>((resolve, reject) => {
+      try {
+        // Check if script already exists
+        const existingScript = document.querySelector('script[src*="paypal.com/web-sdk"]');
+        if (existingScript) {
+          // Wait for existing script to load
+          this.waitForPayPal(resolve, reject, config.loadTimeout);
+          return;
+        }
+
+        // Build SDK URL
+        const urlBuilder = new SdkUrlBuilder(config);
+        const url = urlBuilder.build();
+
+        // Create script element
+        this.script = document.createElement('script');
+        this.script.src = url;
+        this.script.async = true;
+        
+        // Add CSP nonce if provided
+        if (config.cspNonce) {
+          this.script.setAttribute('nonce', config.cspNonce);
+        }
+
+        // Add data attributes
+        if (config.dataAttributes) {
+          Object.entries(config.dataAttributes).forEach(([key, value]) => {
+            this.script!.setAttribute(`data-${key}`, value);
+          });
+        }
+
+        // Handle load event
+        this.script.onload = () => {
+          this.waitForPayPal(resolve, reject, config.loadTimeout);
+        };
+
+        // Handle error event
+        this.script.onerror = (error) => {
+          this.state = SdkState.ERROR;
+          const sdkError = new PayPalSdkError(
+            ErrorCode.SDK_LOAD_FAILED,
+            'Failed to load PayPal SDK script',
+            { originalError: error as Error }
+          );
+          this.errorCallbacks.forEach(cb => cb(sdkError));
+          reject(sdkError);
+        };
+
+        // Append script to document
+        document.head.appendChild(this.script);
+
+      } catch (error) {
+        this.state = SdkState.ERROR;
+        const sdkError = new PayPalSdkError(
+          ErrorCode.SDK_LOAD_FAILED,
+          'Error while loading PayPal SDK',
+          { originalError: error as Error }
+        );
+        reject(sdkError);
+      }
+    });
+
+    return this.loadPromise;
+  }
+
+  /**
+   * Wait for PayPal global to be available
+   */
+  private waitForPayPal(
+    resolve: () => void,
+    reject: (error: Error) => void,
+    timeout: number = 30000
+  ): void {
+    const startTime = Date.now();
+    
+    const checkInterval = setInterval(() => {
+      if (typeof window !== 'undefined' && window.paypal?.createInstance) {
+        clearInterval(checkInterval);
+        this.state = SdkState.READY;
+        this.loadCallbacks.forEach(cb => cb());
+        resolve();
+      } else if (Date.now() - startTime > timeout) {
+        clearInterval(checkInterval);
+        this.state = SdkState.ERROR;
+        const error = new PayPalSdkError(
+          ErrorCode.TIMEOUT_ERROR,
+          `PayPal SDK failed to load within ${timeout}ms`
+        );
+        this.errorCallbacks.forEach(cb => cb(error));
+        reject(error);
+      }
+    }, 100);
+  }
+
+  /**
+   * Unload the SDK
+   */
+  unload(): void {
+    if (this.script && this.script.parentNode) {
+      this.script.parentNode.removeChild(this.script);
+    }
+    
+    this.script = null;
+    this.loadPromise = null;
+    this.state = SdkState.DESTROYED;
+    this.config = null;
+    
+    // Remove PayPal from window
+    if (typeof window !== 'undefined' && window.paypal) {
+      delete (window as any).paypal;
+    }
+  }
+
+  /**
+   * Add load callback
+   */
+  onLoad(callback: () => void): void {
+    if (this.isLoaded()) {
+      callback();
+    } else {
+      this.loadCallbacks.push(callback);
+    }
+  }
+
+  /**
+   * Add error callback
+   */
+  onError(callback: (error: Error) => void): void {
+    this.errorCallbacks.push(callback);
+  }
+
+  /**
+   * Get loaded configuration
+   */
+  getConfig(): SdkConfig | null {
+    return this.config;
+  }
+}

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -1,0 +1,406 @@
+import {
+  SdkInitOptions,
+  SdkInstance,
+  SdkState,
+  SdkEventType,
+  SdkMetadata,
+  CreateInstanceOptions,
+  EligiblePaymentMethods,
+  FindEligibleMethodsOptions,
+  PaymentSessionOptions,
+  ErrorCode,
+  PayPalSdkError,
+  Environment,
+  Component
+} from '@paypal-v6/types';
+import { SdkLoader } from './loader';
+import { EventEmitter } from './events';
+import { PaymentSessionManager, BasePaymentSession, GooglePaySessionWrapper, ApplePaySessionWrapper } from './sessions';
+import { Logger, retry, isBrowserSupported, parsePayPalError } from './utils';
+
+/**
+ * Main PayPal SDK wrapper class
+ */
+export class PayPalSDK {
+  private static instance: PayPalSDK | null = null;
+  
+  private loader: SdkLoader;
+  private events: EventEmitter;
+  private sessionManager: PaymentSessionManager;
+  private logger: Logger;
+  private sdkInstance: SdkInstance | null = null;
+  private eligibleMethods: EligiblePaymentMethods | null = null;
+  private config: SdkInitOptions;
+  private state: SdkState = SdkState.NOT_INITIALIZED;
+  private initPromise: Promise<void> | null = null;
+
+  /**
+   * Get singleton instance
+   */
+  static getInstance(config?: SdkInitOptions): PayPalSDK {
+    if (!PayPalSDK.instance) {
+      if (!config) {
+        throw new PayPalSdkError(
+          ErrorCode.INVALID_CONFIGURATION,
+          'Configuration required for first initialization'
+        );
+      }
+      PayPalSDK.instance = new PayPalSDK(config);
+    } else if (config) {
+      // Update configuration if provided
+      PayPalSDK.instance.updateConfig(config);
+    }
+    
+    return PayPalSDK.instance;
+  }
+
+  /**
+   * Private constructor for singleton
+   */
+  private constructor(config: SdkInitOptions) {
+    // Check browser support
+    if (!isBrowserSupported()) {
+      throw new PayPalSdkError(
+        ErrorCode.BROWSER_NOT_SUPPORTED,
+        'Browser is not supported by PayPal SDK'
+      );
+    }
+
+    this.config = this.validateConfig(config);
+    this.loader = SdkLoader.getInstance();
+    this.events = new EventEmitter();
+    this.sessionManager = new PaymentSessionManager(this.events);
+    this.logger = new Logger(config.logger);
+    
+    // Set up loader callbacks
+    this.setupLoaderCallbacks();
+    
+    // Auto-load if configured
+    if (config.autoLoad !== false) {
+      this.initialize().catch(error => {
+        this.logger.error('Failed to auto-initialize SDK', error);
+      });
+    }
+  }
+
+  /**
+   * Validate configuration
+   */
+  private validateConfig(config: SdkInitOptions): SdkInitOptions {
+    if (!config.clientToken && !config.clientId) {
+      throw new PayPalSdkError(
+        ErrorCode.INVALID_CONFIGURATION,
+        'Either clientToken or clientId is required'
+      );
+    }
+
+    // Set defaults
+    return {
+      ...config,
+      environment: config.environment || Environment.SANDBOX,
+      components: config.components || ['paypal-payments'],
+      pageType: config.pageType || 'checkout',
+      autoLoad: config.autoLoad !== false,
+      loadTimeout: config.loadTimeout || 30000
+    };
+  }
+
+  /**
+   * Update configuration
+   */
+  private updateConfig(config: Partial<SdkInitOptions>): void {
+    this.config = { ...this.config, ...config };
+    this.logger = new Logger(this.config.logger);
+  }
+
+  /**
+   * Set up loader callbacks
+   */
+  private setupLoaderCallbacks(): void {
+    this.loader.onLoad(() => {
+      this.logger.info('PayPal SDK script loaded');
+      this.events.emit(SdkEventType.LOADED);
+      
+      if (this.config.callbacks?.onLoad) {
+        this.config.callbacks.onLoad();
+      }
+    });
+
+    this.loader.onError((error) => {
+      this.logger.error('PayPal SDK script failed to load', error);
+      this.state = SdkState.ERROR;
+      this.events.emit(SdkEventType.ERROR, error);
+      
+      if (this.config.callbacks?.onError) {
+        this.config.callbacks.onError(error);
+      }
+    });
+  }
+
+  /**
+   * Initialize the SDK
+   */
+  async initialize(): Promise<void> {
+    // Return existing promise if already initializing
+    if (this.initPromise) {
+      return this.initPromise;
+    }
+
+    // Check if already initialized
+    if (this.state === SdkState.READY) {
+      return Promise.resolve();
+    }
+
+    this.initPromise = this.performInitialization();
+    return this.initPromise;
+  }
+
+  /**
+   * Perform SDK initialization
+   */
+  private async performInitialization(): Promise<void> {
+    try {
+      this.state = SdkState.LOADING;
+      this.logger.info('Initializing PayPal SDK');
+
+      // Load SDK script
+      await retry(
+        () => this.loader.load(this.config),
+        this.config.retry
+      );
+
+      // Create SDK instance
+      if (this.config.clientToken) {
+        await this.createInstanceWithToken(this.config.clientToken);
+      } else {
+        // For client-id based initialization, instance is created differently
+        // This would typically be handled by the loaded SDK itself
+        this.logger.warn('Client ID based initialization may require additional setup');
+      }
+
+      this.state = SdkState.READY;
+      this.logger.info('PayPal SDK initialized successfully');
+      this.events.emit(SdkEventType.READY);
+      
+      if (this.config.callbacks?.onReady) {
+        this.config.callbacks.onReady();
+      }
+
+    } catch (error) {
+      this.state = SdkState.ERROR;
+      const sdkError = parsePayPalError(error);
+      this.logger.error('Failed to initialize PayPal SDK', sdkError);
+      this.events.emit(SdkEventType.ERROR, sdkError);
+      
+      if (this.config.callbacks?.onError) {
+        this.config.callbacks.onError(sdkError);
+      }
+      
+      throw sdkError;
+    } finally {
+      this.initPromise = null;
+    }
+  }
+
+  /**
+   * Create SDK instance with client token
+   */
+  async createInstanceWithToken(clientToken: string): Promise<void> {
+    if (!window.paypal?.createInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'PayPal global not available'
+      );
+    }
+
+    const options: CreateInstanceOptions = {
+      clientToken,
+      components: this.config.components as Component[],
+      pageType: this.config.pageType,
+      locale: this.config.locale,
+      partnerAttributionId: this.config.partnerAttributionId,
+      clientMetadataId: this.config.clientMetadataId
+    };
+
+    try {
+      this.sdkInstance = await window.paypal.createInstance(options);
+      this.sessionManager.setSdkInstance(this.sdkInstance);
+      this.logger.debug('SDK instance created successfully');
+    } catch (error) {
+      throw parsePayPalError(error);
+    }
+  }
+
+  /**
+   * Find eligible payment methods
+   */
+  async findEligibleMethods(
+    options?: FindEligibleMethodsOptions
+  ): Promise<EligiblePaymentMethods> {
+    await this.ensureInitialized();
+
+    if (!this.sdkInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK instance not available'
+      );
+    }
+
+    try {
+      const findOptions: FindEligibleMethodsOptions = {
+        currencyCode: options?.currencyCode || this.config.currency || 'USD',
+        countryCode: options?.countryCode || this.config.buyerCountry,
+        amount: options?.amount
+      };
+
+      this.eligibleMethods = await this.sdkInstance.findEligibleMethods(findOptions);
+      this.logger.debug('Eligible payment methods found', {
+        methods: this.eligibleMethods.getAllEligible()
+      });
+      
+      return this.eligibleMethods;
+    } catch (error) {
+      throw parsePayPalError(error);
+    }
+  }
+
+  /**
+   * Check if a payment method is eligible
+   */
+  async isPaymentMethodEligible(method: string): Promise<boolean> {
+    if (!this.eligibleMethods) {
+      await this.findEligibleMethods();
+    }
+    
+    return this.eligibleMethods?.isEligible(method) || false;
+  }
+
+  /**
+   * Create PayPal payment session
+   */
+  createPayPalSession(options: PaymentSessionOptions): BasePaymentSession {
+    this.ensureInitializedSync();
+    return this.sessionManager.createPayPalSession(options);
+  }
+
+  /**
+   * Create Venmo payment session
+   */
+  createVenmoSession(options: PaymentSessionOptions): BasePaymentSession {
+    this.ensureInitializedSync();
+    return this.sessionManager.createVenmoSession(options);
+  }
+
+  /**
+   * Create Pay Later payment session
+   */
+  createPayLaterSession(options: PaymentSessionOptions): BasePaymentSession {
+    this.ensureInitializedSync();
+    return this.sessionManager.createPayLaterSession(options);
+  }
+
+  /**
+   * Create PayPal Credit payment session
+   */
+  createCreditSession(options: PaymentSessionOptions): BasePaymentSession {
+    this.ensureInitializedSync();
+    return this.sessionManager.createCreditSession(options);
+  }
+
+  /**
+   * Create Google Pay payment session
+   */
+  createGooglePaySession(): GooglePaySessionWrapper {
+    this.ensureInitializedSync();
+    return this.sessionManager.createGooglePaySession();
+  }
+
+  /**
+   * Create Apple Pay payment session
+   */
+  createApplePaySession(options: PaymentSessionOptions): ApplePaySessionWrapper {
+    this.ensureInitializedSync();
+    return this.sessionManager.createApplePaySession(options);
+  }
+
+  /**
+   * Ensure SDK is initialized (async)
+   */
+  private async ensureInitialized(): Promise<void> {
+    if (this.state !== SdkState.READY) {
+      await this.initialize();
+    }
+  }
+
+  /**
+   * Ensure SDK is initialized (sync check)
+   */
+  private ensureInitializedSync(): void {
+    if (this.state !== SdkState.READY) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK must be initialized before creating sessions. Call initialize() first.'
+      );
+    }
+  }
+
+  /**
+   * Get SDK metadata
+   */
+  getMetadata(): SdkMetadata {
+    return {
+      version: window.paypal?.version || 'unknown',
+      environment: this.config.environment!,
+      components: this.config.components as Component[],
+      features: this.eligibleMethods?.getAllEligible()
+    };
+  }
+
+  /**
+   * Get SDK state
+   */
+  getState(): SdkState {
+    return this.state;
+  }
+
+  /**
+   * Get event emitter
+   */
+  getEvents(): EventEmitter {
+    return this.events;
+  }
+
+  /**
+   * Destroy the SDK
+   */
+  destroy(): void {
+    this.logger.info('Destroying PayPal SDK');
+    
+    // Destroy all sessions
+    this.sessionManager.destroyAll();
+    
+    // Unload script
+    this.loader.unload();
+    
+    // Clear references
+    this.sdkInstance = null;
+    this.eligibleMethods = null;
+    this.state = SdkState.DESTROYED;
+    
+    // Clear singleton
+    PayPalSDK.instance = null;
+    
+    this.events.emit(SdkEventType.DESTROYED);
+    this.events.removeAllListeners();
+  }
+
+  /**
+   * Reset the SDK (destroy and reinitialize)
+   */
+  async reset(): Promise<void> {
+    const config = { ...this.config };
+    this.destroy();
+    PayPalSDK.instance = new PayPalSDK(config);
+    await PayPalSDK.instance.initialize();
+  }
+}

--- a/packages/core/src/sessions.ts
+++ b/packages/core/src/sessions.ts
@@ -1,0 +1,451 @@
+import {
+  PaymentSession,
+  PaymentSessionOptions,
+  StartSessionOptions,
+  OrderPromise,
+  SdkInstance,
+  GooglePaySession,
+  ApplePaySession,
+  PaymentMethod,
+  ErrorCode,
+  PayPalSdkError,
+  SdkEventType
+} from '@paypal-v6/types';
+import { EventEmitter } from './events';
+
+/**
+ * Base payment session wrapper
+ */
+export class BasePaymentSession implements PaymentSession {
+  protected session: PaymentSession | null = null;
+  protected active: boolean = false;
+  protected events: EventEmitter;
+  protected paymentMethod: PaymentMethod;
+
+  constructor(
+    session: PaymentSession,
+    paymentMethod: PaymentMethod,
+    events: EventEmitter
+  ) {
+    this.session = session;
+    this.paymentMethod = paymentMethod;
+    this.events = events;
+  }
+
+  /**
+   * Start the payment session
+   */
+  async start(
+    options: StartSessionOptions,
+    orderPromise: Promise<OrderPromise>
+  ): Promise<void> {
+    if (this.active) {
+      throw new PayPalSdkError(
+        ErrorCode.SESSION_ALREADY_ACTIVE,
+        'Payment session is already active'
+      );
+    }
+
+    if (!this.session) {
+      throw new PayPalSdkError(
+        ErrorCode.SESSION_NOT_FOUND,
+        'Payment session not initialized'
+      );
+    }
+
+    try {
+      this.active = true;
+      this.events.emit(SdkEventType.SESSION_STARTED, {
+        paymentMethod: this.paymentMethod,
+        options
+      });
+
+      await this.session.start(options, orderPromise);
+      
+    } catch (error) {
+      this.active = false;
+      this.events.emit(SdkEventType.SESSION_ENDED, {
+        paymentMethod: this.paymentMethod,
+        error
+      });
+      
+      if (error instanceof PayPalSdkError) {
+        throw error;
+      }
+      
+      throw new PayPalSdkError(
+        ErrorCode.PAYMENT_FAILED,
+        'Failed to start payment session',
+        { originalError: error as Error }
+      );
+    }
+  }
+
+  /**
+   * Cancel the current session
+   */
+  cancel(): void {
+    if (!this.active) {
+      return;
+    }
+
+    if (this.session) {
+      this.session.cancel();
+    }
+    
+    this.active = false;
+    this.events.emit(SdkEventType.SESSION_ENDED, {
+      paymentMethod: this.paymentMethod,
+      cancelled: true
+    });
+  }
+
+  /**
+   * Destroy the session and clean up
+   */
+  destroy(): void {
+    if (this.session) {
+      this.session.destroy();
+      this.session = null;
+    }
+    
+    this.active = false;
+    this.events.emit(SdkEventType.SESSION_ENDED, {
+      paymentMethod: this.paymentMethod,
+      destroyed: true
+    });
+  }
+
+  /**
+   * Check if session is active
+   */
+  isActive(): boolean {
+    return this.active;
+  }
+}
+
+/**
+ * Google Pay session wrapper
+ */
+export class GooglePaySessionWrapper extends BasePaymentSession implements GooglePaySession {
+  private googlePaySession: GooglePaySession;
+
+  constructor(
+    session: GooglePaySession,
+    events: EventEmitter
+  ) {
+    super(session, PaymentMethod.GOOGLE_PAY, events);
+    this.googlePaySession = session;
+  }
+
+  /**
+   * Get Google Pay configuration
+   */
+  async getGooglePayConfig(): Promise<any> {
+    if (!this.googlePaySession) {
+      throw new PayPalSdkError(
+        ErrorCode.SESSION_NOT_FOUND,
+        'Google Pay session not initialized'
+      );
+    }
+
+    try {
+      return await this.googlePaySession.getGooglePayConfig();
+    } catch (error) {
+      throw new PayPalSdkError(
+        ErrorCode.INVALID_CONFIGURATION,
+        'Failed to get Google Pay configuration',
+        { originalError: error as Error }
+      );
+    }
+  }
+
+  /**
+   * Confirm an order with Google Pay
+   */
+  async confirmOrder(options: {
+    orderId: string;
+    paymentMethodData: any;
+  }): Promise<{ status: string }> {
+    if (!this.googlePaySession) {
+      throw new PayPalSdkError(
+        ErrorCode.SESSION_NOT_FOUND,
+        'Google Pay session not initialized'
+      );
+    }
+
+    try {
+      return await this.googlePaySession.confirmOrder(options);
+    } catch (error) {
+      throw new PayPalSdkError(
+        ErrorCode.PAYMENT_FAILED,
+        'Failed to confirm Google Pay order',
+        { 
+          originalError: error as Error,
+          orderId: options.orderId
+        }
+      );
+    }
+  }
+}
+
+/**
+ * Apple Pay session wrapper
+ */
+export class ApplePaySessionWrapper extends BasePaymentSession implements ApplePaySession {
+  private applePaySession: ApplePaySession;
+
+  constructor(
+    session: ApplePaySession,
+    events: EventEmitter
+  ) {
+    super(session, PaymentMethod.APPLE_PAY, events);
+    this.applePaySession = session;
+  }
+
+  /**
+   * Get Apple Pay configuration
+   */
+  async getApplePayConfig(): Promise<any> {
+    if (!this.applePaySession) {
+      throw new PayPalSdkError(
+        ErrorCode.SESSION_NOT_FOUND,
+        'Apple Pay session not initialized'
+      );
+    }
+
+    try {
+      return await this.applePaySession.getApplePayConfig();
+    } catch (error) {
+      throw new PayPalSdkError(
+        ErrorCode.INVALID_CONFIGURATION,
+        'Failed to get Apple Pay configuration',
+        { originalError: error as Error }
+      );
+    }
+  }
+
+  /**
+   * Validate merchant session
+   */
+  async validateMerchant(validationURL: string): Promise<any> {
+    if (!this.applePaySession) {
+      throw new PayPalSdkError(
+        ErrorCode.SESSION_NOT_FOUND,
+        'Apple Pay session not initialized'
+      );
+    }
+
+    try {
+      return await this.applePaySession.validateMerchant(validationURL);
+    } catch (error) {
+      throw new PayPalSdkError(
+        ErrorCode.PAYMENT_FAILED,
+        'Failed to validate Apple Pay merchant',
+        { originalError: error as Error }
+      );
+    }
+  }
+}
+
+/**
+ * Payment session manager
+ */
+export class PaymentSessionManager {
+  private sdkInstance: SdkInstance | null = null;
+  private sessions: Map<string, BasePaymentSession> = new Map();
+  private events: EventEmitter;
+
+  constructor(events: EventEmitter) {
+    this.events = events;
+  }
+
+  /**
+   * Set SDK instance
+   */
+  setSdkInstance(instance: SdkInstance): void {
+    this.sdkInstance = instance;
+  }
+
+  /**
+   * Create PayPal payment session
+   */
+  createPayPalSession(options: PaymentSessionOptions): BasePaymentSession {
+    if (!this.sdkInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK instance not initialized'
+      );
+    }
+
+    const sessionOptions = this.wrapSessionOptions(options, PaymentMethod.PAYPAL);
+    const session = this.sdkInstance.createPayPalOneTimePaymentSession(sessionOptions);
+    const wrappedSession = new BasePaymentSession(session, PaymentMethod.PAYPAL, this.events);
+    
+    this.sessions.set(`paypal_${Date.now()}`, wrappedSession);
+    return wrappedSession;
+  }
+
+  /**
+   * Create Venmo payment session
+   */
+  createVenmoSession(options: PaymentSessionOptions): BasePaymentSession {
+    if (!this.sdkInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK instance not initialized'
+      );
+    }
+
+    const sessionOptions = this.wrapSessionOptions(options, PaymentMethod.VENMO);
+    const session = this.sdkInstance.createVenmoOneTimePaymentSession(sessionOptions);
+    const wrappedSession = new BasePaymentSession(session, PaymentMethod.VENMO, this.events);
+    
+    this.sessions.set(`venmo_${Date.now()}`, wrappedSession);
+    return wrappedSession;
+  }
+
+  /**
+   * Create Pay Later payment session
+   */
+  createPayLaterSession(options: PaymentSessionOptions): BasePaymentSession {
+    if (!this.sdkInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK instance not initialized'
+      );
+    }
+
+    const sessionOptions = this.wrapSessionOptions(options, PaymentMethod.PAYLATER);
+    const session = this.sdkInstance.createPayLaterOneTimePaymentSession(sessionOptions);
+    const wrappedSession = new BasePaymentSession(session, PaymentMethod.PAYLATER, this.events);
+    
+    this.sessions.set(`paylater_${Date.now()}`, wrappedSession);
+    return wrappedSession;
+  }
+
+  /**
+   * Create PayPal Credit payment session
+   */
+  createCreditSession(options: PaymentSessionOptions): BasePaymentSession {
+    if (!this.sdkInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK instance not initialized'
+      );
+    }
+
+    const sessionOptions = this.wrapSessionOptions(options, PaymentMethod.CREDIT);
+    const session = this.sdkInstance.createPayPalCreditOneTimePaymentSession(sessionOptions);
+    const wrappedSession = new BasePaymentSession(session, PaymentMethod.CREDIT, this.events);
+    
+    this.sessions.set(`credit_${Date.now()}`, wrappedSession);
+    return wrappedSession;
+  }
+
+  /**
+   * Create Google Pay payment session
+   */
+  createGooglePaySession(): GooglePaySessionWrapper {
+    if (!this.sdkInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK instance not initialized'
+      );
+    }
+
+    const session = this.sdkInstance.createGooglePayOneTimePaymentSession();
+    const wrappedSession = new GooglePaySessionWrapper(session, this.events);
+    
+    this.sessions.set(`googlepay_${Date.now()}`, wrappedSession);
+    return wrappedSession;
+  }
+
+  /**
+   * Create Apple Pay payment session
+   */
+  createApplePaySession(options: PaymentSessionOptions): ApplePaySessionWrapper {
+    if (!this.sdkInstance) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'SDK instance not initialized'
+      );
+    }
+
+    const sessionOptions = this.wrapSessionOptions(options, PaymentMethod.APPLE_PAY);
+    const session = this.sdkInstance.createApplePayOneTimePaymentSession(sessionOptions);
+    const wrappedSession = new ApplePaySessionWrapper(session, this.events);
+    
+    this.sessions.set(`applepay_${Date.now()}`, wrappedSession);
+    return wrappedSession;
+  }
+
+  /**
+   * Wrap session options with event emitters
+   */
+  private wrapSessionOptions(
+    options: PaymentSessionOptions,
+    paymentMethod: PaymentMethod
+  ): PaymentSessionOptions {
+    return {
+      ...options,
+      onApprove: async (data) => {
+        this.events.emit(SdkEventType.PAYMENT_APPROVED, {
+          paymentMethod,
+          data
+        });
+        
+        if (options.onApprove) {
+          await options.onApprove(data);
+        }
+      },
+      onCancel: (data) => {
+        this.events.emit(SdkEventType.PAYMENT_CANCELLED, {
+          paymentMethod,
+          data
+        });
+        
+        if (options.onCancel) {
+          options.onCancel(data);
+        }
+      },
+      onError: (error) => {
+        this.events.emit(SdkEventType.PAYMENT_ERROR, {
+          paymentMethod,
+          error
+        });
+        
+        if (options.onError) {
+          options.onError(error);
+        }
+      }
+    };
+  }
+
+  /**
+   * Destroy all sessions
+   */
+  destroyAll(): void {
+    this.sessions.forEach(session => {
+      try {
+        session.destroy();
+      } catch (error) {
+        console.error('Error destroying session:', error);
+      }
+    });
+    this.sessions.clear();
+  }
+
+  /**
+   * Get active sessions count
+   */
+  getActiveSessionsCount(): number {
+    let count = 0;
+    this.sessions.forEach(session => {
+      if (session.isActive()) {
+        count++;
+      }
+    });
+    return count;
+  }
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,0 +1,419 @@
+import {
+  RetryConfig,
+  PayPalSdkError,
+  ErrorCode,
+  LoggerConfig
+} from '@paypal-v6/types';
+
+/**
+ * Default retry configuration
+ */
+export const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
+  maxAttempts: 3,
+  initialDelay: 1000,
+  maxDelay: 30000,
+  backoffMultiplier: 2,
+  shouldRetry: (error: PayPalSdkError, attemptNumber: number) => {
+    // Don't retry certain errors
+    const nonRetryableErrors = [
+      ErrorCode.INVALID_CLIENT_TOKEN,
+      ErrorCode.INVALID_CONFIGURATION,
+      ErrorCode.PAYMENT_CANCELLED,
+      ErrorCode.BROWSER_NOT_SUPPORTED,
+      ErrorCode.DEVICE_NOT_SUPPORTED
+    ];
+    
+    if (nonRetryableErrors.includes(error.code)) {
+      return false;
+    }
+    
+    // Retry network and timeout errors
+    const retryableErrors = [
+      ErrorCode.NETWORK_ERROR,
+      ErrorCode.TIMEOUT_ERROR,
+      ErrorCode.SERVER_ERROR
+    ];
+    
+    return retryableErrors.includes(error.code) && attemptNumber < 3;
+  }
+};
+
+/**
+ * Retry helper function
+ */
+export async function retry<T>(
+  fn: () => Promise<T>,
+  config: RetryConfig = {}
+): Promise<T> {
+  const options = { ...DEFAULT_RETRY_CONFIG, ...config };
+  let lastError: PayPalSdkError | null = null;
+  let delay = options.initialDelay;
+  
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error instanceof PayPalSdkError 
+        ? error 
+        : new PayPalSdkError(
+            ErrorCode.UNKNOWN_ERROR,
+            'Unknown error during retry',
+            { originalError: error as Error }
+          );
+      
+      // Check if we should retry
+      if (attempt < options.maxAttempts && options.shouldRetry(lastError, attempt)) {
+        // Wait before retrying
+        await sleep(Math.min(delay, options.maxDelay));
+        
+        // Increase delay for next attempt
+        delay *= options.backoffMultiplier;
+      } else {
+        // Don't retry, throw the error
+        break;
+      }
+    }
+  }
+  
+  throw lastError || new PayPalSdkError(
+    ErrorCode.UNKNOWN_ERROR,
+    'Retry failed with unknown error'
+  );
+}
+
+/**
+ * Sleep helper
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Debounce helper
+ */
+export function debounce<T extends (...args: any[]) => any>(
+  fn: T,
+  delay: number
+): (...args: Parameters<T>) => void {
+  let timeoutId: NodeJS.Timeout | null = null;
+  
+  return (...args: Parameters<T>) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    
+    timeoutId = setTimeout(() => {
+      fn(...args);
+      timeoutId = null;
+    }, delay);
+  };
+}
+
+/**
+ * Throttle helper
+ */
+export function throttle<T extends (...args: any[]) => any>(
+  fn: T,
+  limit: number
+): (...args: Parameters<T>) => void {
+  let inThrottle = false;
+  
+  return (...args: Parameters<T>) => {
+    if (!inThrottle) {
+      fn(...args);
+      inThrottle = true;
+      
+      setTimeout(() => {
+        inThrottle = false;
+      }, limit);
+    }
+  };
+}
+
+/**
+ * Logger implementation
+ */
+export class Logger {
+  private config: LoggerConfig;
+  
+  constructor(config: LoggerConfig = {}) {
+    this.config = {
+      enabled: config.enabled ?? true,
+      level: config.level ?? 'info',
+      includeTimestamp: config.includeTimestamp ?? true,
+      includeStackTrace: config.includeStackTrace ?? false,
+      logger: config.logger ?? console
+    };
+  }
+  
+  /**
+   * Check if log level is enabled
+   */
+  private isLevelEnabled(level: string): boolean {
+    if (!this.config.enabled) return false;
+    
+    const levels = ['debug', 'info', 'warn', 'error'];
+    const currentLevelIndex = levels.indexOf(this.config.level!);
+    const targetLevelIndex = levels.indexOf(level);
+    
+    return targetLevelIndex >= currentLevelIndex;
+  }
+  
+  /**
+   * Format log message
+   */
+  private formatMessage(level: string, message: string): string {
+    let formatted = '';
+    
+    if (this.config.includeTimestamp) {
+      formatted += `[${new Date().toISOString()}] `;
+    }
+    
+    formatted += `[${level.toUpperCase()}] ${message}`;
+    
+    return formatted;
+  }
+  
+  /**
+   * Debug log
+   */
+  debug(message: string, ...args: any[]): void {
+    if (this.isLevelEnabled('debug')) {
+      this.config.logger!.debug(this.formatMessage('debug', message), ...args);
+    }
+  }
+  
+  /**
+   * Info log
+   */
+  info(message: string, ...args: any[]): void {
+    if (this.isLevelEnabled('info')) {
+      this.config.logger!.info(this.formatMessage('info', message), ...args);
+    }
+  }
+  
+  /**
+   * Warning log
+   */
+  warn(message: string, ...args: any[]): void {
+    if (this.isLevelEnabled('warn')) {
+      this.config.logger!.warn(this.formatMessage('warn', message), ...args);
+    }
+  }
+  
+  /**
+   * Error log
+   */
+  error(message: string, error?: Error | PayPalSdkError, ...args: any[]): void {
+    if (this.isLevelEnabled('error')) {
+      const formatted = this.formatMessage('error', message);
+      
+      if (error && this.config.includeStackTrace && error.stack) {
+        this.config.logger!.error(formatted, error.stack, ...args);
+      } else if (error) {
+        this.config.logger!.error(formatted, error.message, ...args);
+      } else {
+        this.config.logger!.error(formatted, ...args);
+      }
+    }
+  }
+}
+
+/**
+ * Validate email address
+ */
+export function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+/**
+ * Validate currency code
+ */
+export function isValidCurrencyCode(code: string): boolean {
+  // Common currency codes
+  const validCodes = [
+    'USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CNY', 'CHF',
+    'SEK', 'NZD', 'MXN', 'SGD', 'HKD', 'NOK', 'KRW', 'TRY',
+    'RUB', 'INR', 'BRL', 'ZAR', 'DKK', 'PLN', 'THB', 'IDR',
+    'HUF', 'CZK', 'ILS', 'CLP', 'PHP', 'AED', 'COP', 'SAR'
+  ];
+  
+  return validCodes.includes(code.toUpperCase());
+}
+
+/**
+ * Validate amount
+ */
+export function isValidAmount(amount: string | number): boolean {
+  const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
+  return !isNaN(numAmount) && numAmount > 0 && isFinite(numAmount);
+}
+
+/**
+ * Format amount for PayPal
+ */
+export function formatAmount(amount: number | string, decimals: number = 2): string {
+  const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
+  return numAmount.toFixed(decimals);
+}
+
+/**
+ * Parse PayPal error response
+ */
+export function parsePayPalError(error: any): PayPalSdkError {
+  // Check if it's already a PayPalSdkError
+  if (error instanceof PayPalSdkError) {
+    return error;
+  }
+  
+  // Try to parse PayPal API error format
+  if (error?.name === 'INVALID_REQUEST' || error?.name === 'VALIDATION_ERROR') {
+    return new PayPalSdkError(
+      ErrorCode.INVALID_CONFIGURATION,
+      error.message || 'Invalid request',
+      {
+        debugId: error.debug_id,
+        details: error.details
+      }
+    );
+  }
+  
+  if (error?.name === 'AUTHENTICATION_FAILURE') {
+    return new PayPalSdkError(
+      ErrorCode.INVALID_CLIENT_TOKEN,
+      error.message || 'Authentication failed',
+      {
+        debugId: error.debug_id
+      }
+    );
+  }
+  
+  if (error?.name === 'NOT_AUTHORIZED') {
+    return new PayPalSdkError(
+      ErrorCode.PAYMENT_NOT_APPROVED,
+      error.message || 'Not authorized',
+      {
+        debugId: error.debug_id
+      }
+    );
+  }
+  
+  // Network errors
+  if (error?.code === 'ECONNREFUSED' || error?.code === 'ENOTFOUND') {
+    return new PayPalSdkError(
+      ErrorCode.NETWORK_ERROR,
+      'Network connection failed',
+      {
+        originalError: error
+      }
+    );
+  }
+  
+  if (error?.code === 'ETIMEDOUT' || error?.code === 'ECONNABORTED') {
+    return new PayPalSdkError(
+      ErrorCode.TIMEOUT_ERROR,
+      'Request timed out',
+      {
+        originalError: error
+      }
+    );
+  }
+  
+  // Default to unknown error
+  return new PayPalSdkError(
+    ErrorCode.UNKNOWN_ERROR,
+    error?.message || 'An unknown error occurred',
+    {
+      originalError: error
+    }
+  );
+}
+
+/**
+ * Deep merge objects
+ */
+export function deepMerge<T extends Record<string, any>>(
+  target: T,
+  ...sources: Partial<T>[]
+): T {
+  if (!sources.length) return target;
+  
+  const source = sources.shift();
+  
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        deepMerge(target[key] as Record<string, any>, source[key] as Record<string, any>);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+  
+  return deepMerge(target, ...sources);
+}
+
+/**
+ * Check if value is an object
+ */
+function isObject(item: any): item is Record<string, any> {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+/**
+ * Generate unique ID
+ */
+export function generateUniqueId(prefix: string = 'id'): string {
+  const timestamp = Date.now().toString(36);
+  const randomStr = Math.random().toString(36).substring(2, 9);
+  return `${prefix}_${timestamp}_${randomStr}`;
+}
+
+/**
+ * Check if browser supports PayPal SDK
+ */
+export function isBrowserSupported(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  
+  // Check for required browser features
+  const hasPromise = typeof Promise !== 'undefined';
+  const hasFetch = typeof fetch !== 'undefined';
+  const hasJSON = typeof JSON !== 'undefined';
+  
+  // Check for minimum browser versions (very basic check)
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  
+  // Internet Explorer is not supported
+  if (userAgent.indexOf('msie') !== -1 || userAgent.indexOf('trident') !== -1) {
+    return false;
+  }
+  
+  return hasPromise && hasFetch && hasJSON;
+}
+
+/**
+ * Get device type
+ */
+export function getDeviceType(): 'mobile' | 'tablet' | 'desktop' {
+  if (typeof window === 'undefined') {
+    return 'desktop';
+  }
+  
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  
+  // Check for mobile devices
+  if (/android|webos|iphone|ipod|blackberry|iemobile|opera mini/i.test(userAgent)) {
+    return 'mobile';
+  }
+  
+  // Check for tablets
+  if (/ipad|tablet|playbook|silk/i.test(userAgent)) {
+    return 'tablet';
+  }
+  
+  return 'desktop';
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  splitting: false,
+  external: ['@paypal-v6/types'],
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@paypal-v6/react",
+  "version": "0.1.0",
+  "description": "React hooks and components for PayPal v6 Web SDK",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@paypal-v6/core": "workspace:*",
+    "@paypal-v6/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "tsup": "^8.3.5",
+    "vitest": "^2.1.8",
+    "typescript": "^5.8.3"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/react/src/components/ApplePayButton.tsx
+++ b/packages/react/src/components/ApplePayButton.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import { useApplePay } from '../hooks/useApplePay';
+import {
+  CreateOrderRequest,
+  PaymentSessionOptions
+} from '@paypal-v6/types';
+
+/**
+ * Apple Pay button props
+ */
+export interface ApplePayButtonProps {
+  /** Amount for the transaction */
+  amount: string;
+  
+  /** Currency code */
+  currency?: string;
+  
+  /** Country code */
+  countryCode?: string;
+  
+  /** Create order function */
+  createOrder: () => Promise<{ orderId: string }>;
+  
+  /** Payment session options */
+  sessionOptions?: PaymentSessionOptions;
+  
+  /** Apple Pay button style */
+  buttonStyle?: 'black' | 'white' | 'white-outline';
+  
+  /** Button type */
+  buttonType?: 'plain' | 'buy' | 'donate' | 'checkout' | 'book' | 'subscribe';
+  
+  /** Button locale */
+  buttonLocale?: string;
+  
+  /** Custom class name */
+  className?: string;
+  
+  /** Disabled state */
+  disabled?: boolean;
+  
+  /** Container ID */
+  containerId?: string;
+}
+
+/**
+ * Apple Pay button component
+ */
+export function ApplePayButton({
+  amount,
+  currency = 'USD',
+  countryCode = 'US',
+  createOrder,
+  sessionOptions = {},
+  buttonStyle = 'black',
+  buttonType = 'buy',
+  buttonLocale = 'en-US',
+  className,
+  disabled = false,
+  containerId = 'applepay-button-container'
+}: ApplePayButtonProps) {
+  const { isReady } = usePayPalSDK();
+  const { session, config, isEligible, isSupported } = useApplePay();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  /**
+   * Handle Apple Pay click
+   */
+  const handleApplePayClick = useCallback(async () => {
+    if (!session || isProcessing || disabled) {
+      return;
+    }
+
+    try {
+      setIsProcessing(true);
+      
+      // Start Apple Pay session
+      const orderPromise = createOrder();
+      await session.start(
+        { presentationMode: 'modal' },
+        orderPromise
+      );
+      
+    } catch (error) {
+      console.error('Apple Pay payment failed:', error);
+      if (sessionOptions.onError) {
+        sessionOptions.onError(error as Error);
+      }
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [session, isProcessing, disabled, createOrder, sessionOptions]);
+
+  /**
+   * Set up Apple Pay button
+   */
+  useEffect(() => {
+    if (!isReady || !isEligible || !isSupported) {
+      return;
+    }
+
+    const container = document.getElementById(containerId);
+    if (!container) {
+      return;
+    }
+
+    // Clear existing content
+    container.innerHTML = '';
+
+    // Create Apple Pay button
+    const button = document.createElement('apple-pay-button');
+    button.setAttribute('buttonstyle', buttonStyle);
+    button.setAttribute('type', buttonType);
+    button.setAttribute('locale', buttonLocale);
+    
+    // Apply styles
+    (button as HTMLElement).style.width = '100%';
+    (button as HTMLElement).style.height = '45px';
+    
+    if (disabled) {
+      (button as HTMLElement).style.opacity = '0.6';
+      (button as HTMLElement).style.pointerEvents = 'none';
+    }
+
+    // Add click handler
+    button.addEventListener('click', handleApplePayClick);
+
+    // Append to container
+    container.appendChild(button);
+
+    // Cleanup
+    return () => {
+      button.removeEventListener('click', handleApplePayClick);
+    };
+  }, [
+    isReady,
+    isEligible,
+    isSupported,
+    containerId,
+    buttonStyle,
+    buttonType,
+    buttonLocale,
+    disabled,
+    handleApplePayClick
+  ]);
+
+  if (!isSupported || !isEligible) {
+    return null;
+  }
+
+  return (
+    <div 
+      id={containerId}
+      className={className}
+      style={{ minHeight: '45px' }}
+    />
+  );
+}

--- a/packages/react/src/components/ErrorBoundary.tsx
+++ b/packages/react/src/components/ErrorBoundary.tsx
@@ -1,0 +1,146 @@
+import React, { Component, ReactNode } from 'react';
+import { PayPalSdkError } from '@paypal-v6/types';
+
+/**
+ * Error boundary props
+ */
+export interface ErrorBoundaryProps {
+  /** Children components */
+  children: ReactNode;
+  
+  /** Fallback component to render on error */
+  fallback?: (error: Error, resetError: () => void) => ReactNode;
+  
+  /** Callback when error occurs */
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+  
+  /** Whether to log errors to console */
+  logErrors?: boolean;
+}
+
+/**
+ * Error boundary state
+ */
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error boundary component for catching React errors
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return {
+      hasError: true,
+      error
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    const { onError, logErrors = true } = this.props;
+
+    if (logErrors) {
+      console.error('PayPal SDK Error Boundary caught:', error, errorInfo);
+    }
+
+    if (onError) {
+      onError(error, errorInfo);
+    }
+  }
+
+  resetError = () => {
+    this.setState({
+      hasError: false,
+      error: null
+    });
+  };
+
+  render() {
+    const { hasError, error } = this.state;
+    const { children, fallback } = this.props;
+
+    if (hasError && error) {
+      if (fallback) {
+        return fallback(error, this.resetError);
+      }
+
+      // Default fallback UI
+      return (
+        <div style={defaultErrorStyles.container}>
+          <div style={defaultErrorStyles.content}>
+            <h2 style={defaultErrorStyles.title}>Payment Error</h2>
+            <p style={defaultErrorStyles.message}>
+              {error instanceof PayPalSdkError
+                ? error.message
+                : 'An unexpected error occurred while processing your payment.'}
+            </p>
+            {error instanceof PayPalSdkError && error.debugId && (
+              <p style={defaultErrorStyles.debugId}>
+                Debug ID: {error.debugId}
+              </p>
+            )}
+            <button
+              onClick={this.resetError}
+              style={defaultErrorStyles.button}
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}
+
+/**
+ * Default error styles
+ */
+const defaultErrorStyles = {
+  container: {
+    padding: '20px',
+    textAlign: 'center' as const,
+    backgroundColor: '#f8f9fa',
+    borderRadius: '8px',
+    border: '1px solid #dee2e6'
+  },
+  content: {
+    maxWidth: '500px',
+    margin: '0 auto'
+  },
+  title: {
+    color: '#dc3545',
+    fontSize: '24px',
+    marginBottom: '16px'
+  },
+  message: {
+    color: '#495057',
+    fontSize: '16px',
+    marginBottom: '12px'
+  },
+  debugId: {
+    color: '#6c757d',
+    fontSize: '14px',
+    fontFamily: 'monospace',
+    marginBottom: '20px'
+  },
+  button: {
+    backgroundColor: '#007bff',
+    color: 'white',
+    border: 'none',
+    borderRadius: '4px',
+    padding: '10px 20px',
+    fontSize: '16px',
+    cursor: 'pointer'
+  }
+};

--- a/packages/react/src/components/GooglePayButton.tsx
+++ b/packages/react/src/components/GooglePayButton.tsx
@@ -1,0 +1,307 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import { useGooglePay } from '../hooks/useGooglePay';
+import {
+  GooglePayTransactionInfo,
+  CreateOrderRequest,
+  ErrorCode,
+  PayPalSdkError
+} from '@paypal-v6/types';
+
+/**
+ * Google Pay button props
+ */
+export interface GooglePayButtonProps {
+  /** Amount for the transaction */
+  amount: string;
+  
+  /** Currency code */
+  currency?: string;
+  
+  /** Country code */
+  countryCode?: string;
+  
+  /** Create order function */
+  createOrder: (orderPayload: CreateOrderRequest) => Promise<{ id: string }>;
+  
+  /** Capture order function */
+  captureOrder: (orderId: string) => Promise<any>;
+  
+  /** Transaction info builder */
+  buildTransactionInfo?: (amount: string) => GooglePayTransactionInfo;
+  
+  /** Google Pay environment */
+  environment?: 'TEST' | 'PRODUCTION';
+  
+  /** Button type */
+  buttonType?: 'book' | 'buy' | 'checkout' | 'donate' | 'order' | 'pay' | 'plain' | 'subscribe';
+  
+  /** Button color */
+  buttonColor?: 'default' | 'black' | 'white';
+  
+  /** Button locale */
+  buttonLocale?: string;
+  
+  /** Button size mode */
+  buttonSizeMode?: 'static' | 'fill';
+  
+  /** Callback on success */
+  onSuccess?: (result: any) => void;
+  
+  /** Callback on error */
+  onError?: (error: Error) => void;
+  
+  /** Callback on cancel */
+  onCancel?: () => void;
+  
+  /** Custom class name */
+  className?: string;
+  
+  /** Container ID for button */
+  containerId?: string;
+}
+
+/**
+ * Google Pay button component
+ */
+export function GooglePayButton({
+  amount,
+  currency = 'USD',
+  countryCode = 'US',
+  createOrder,
+  captureOrder,
+  buildTransactionInfo,
+  environment = 'TEST',
+  buttonType = 'pay',
+  buttonColor = 'default',
+  buttonLocale,
+  buttonSizeMode = 'static',
+  onSuccess,
+  onError,
+  onCancel,
+  className,
+  containerId = 'googlepay-button-container'
+}: GooglePayButtonProps) {
+  const { isReady } = usePayPalSDK();
+  const { session, config, isEligible } = useGooglePay();
+  const [paymentsClient, setPaymentsClient] = useState<any>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  /**
+   * Build default transaction info
+   */
+  const getTransactionInfo = useCallback((): GooglePayTransactionInfo => {
+    if (buildTransactionInfo) {
+      return buildTransactionInfo(amount);
+    }
+
+    const totalAmount = parseFloat(amount);
+    const subtotal = (totalAmount * 0.9).toFixed(2);
+    const tax = (totalAmount * 0.1).toFixed(2);
+
+    return {
+      displayItems: [
+        {
+          label: 'Subtotal',
+          type: 'SUBTOTAL',
+          price: subtotal
+        },
+        {
+          label: 'Tax',
+          type: 'TAX',
+          price: tax
+        }
+      ],
+      countryCode,
+      currencyCode: currency,
+      totalPriceStatus: 'FINAL',
+      totalPrice: amount,
+      totalPriceLabel: 'Total'
+    };
+  }, [amount, currency, countryCode, buildTransactionInfo]);
+
+  /**
+   * Handle payment authorization
+   */
+  const onPaymentAuthorized = useCallback(async (paymentData: any) => {
+    setIsProcessing(true);
+
+    try {
+      // Build order payload for PayPal
+      const orderPayload: CreateOrderRequest = {
+        intent: 'CAPTURE',
+        purchaseUnits: [
+          {
+            amount: {
+              currencyCode: currency,
+              value: amount
+            }
+          }
+        ],
+        paymentSource: {
+          googlePay: {
+            attributes: {
+              verification: {
+                method: 'SCA_WHEN_REQUIRED'
+              }
+            }
+          }
+        }
+      };
+
+      // Create order
+      const { id: orderId } = await createOrder(orderPayload);
+
+      // Confirm order with Google Pay session
+      if (session) {
+        const { status } = await session.confirmOrder({
+          orderId,
+          paymentMethodData: paymentData.paymentMethodData
+        });
+
+        if (status !== 'PAYER_ACTION_REQUIRED') {
+          // Capture the order
+          const result = await captureOrder(orderId);
+          
+          if (onSuccess) {
+            onSuccess(result);
+          }
+        }
+      }
+
+      return { transactionState: 'SUCCESS' };
+      
+    } catch (error) {
+      console.error('Google Pay payment failed:', error);
+      
+      if (onError) {
+        onError(error as Error);
+      }
+      
+      return {
+        transactionState: 'ERROR',
+        error: {
+          message: (error as Error).message
+        }
+      };
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [amount, currency, createOrder, captureOrder, session, onSuccess, onError]);
+
+  /**
+   * Handle button click
+   */
+  const onGooglePayButtonClick = useCallback(async () => {
+    if (!paymentsClient || !config || isProcessing) {
+      return;
+    }
+
+    try {
+      const paymentDataRequest = {
+        apiVersion: config.apiVersion,
+        apiVersionMinor: config.apiVersionMinor,
+        allowedPaymentMethods: config.allowedPaymentMethods,
+        merchantInfo: config.merchantInfo,
+        transactionInfo: getTransactionInfo(),
+        callbackIntents: ['PAYMENT_AUTHORIZATION']
+      };
+
+      await paymentsClient.loadPaymentData(paymentDataRequest);
+      
+    } catch (error) {
+      if ((error as any).statusCode === 'CANCELED') {
+        if (onCancel) {
+          onCancel();
+        }
+      } else {
+        console.error('Google Pay error:', error);
+        if (onError) {
+          onError(error as Error);
+        }
+      }
+    }
+  }, [paymentsClient, config, isProcessing, getTransactionInfo, onCancel, onError]);
+
+  /**
+   * Initialize Google Pay
+   */
+  useEffect(() => {
+    if (!isReady || !isEligible || !config || !window.google?.payments) {
+      return;
+    }
+
+    const initializeGooglePay = async () => {
+      try {
+        // Create payments client
+        const client = new google.payments.api.PaymentsClient({
+          environment,
+          paymentDataCallbacks: {
+            onPaymentAuthorized
+          }
+        });
+
+        // Check if ready to pay
+        const isReadyToPay = await client.isReadyToPay({
+          apiVersion: config.apiVersion,
+          apiVersionMinor: config.apiVersionMinor,
+          allowedPaymentMethods: config.allowedPaymentMethods
+        });
+
+        if (isReadyToPay.result) {
+          setPaymentsClient(client);
+
+          // Create button
+          const container = document.getElementById(containerId);
+          if (container) {
+            // Clear existing button
+            container.innerHTML = '';
+            
+            // Create new button
+            const button = client.createButton({
+              onClick: onGooglePayButtonClick,
+              buttonType,
+              buttonColor,
+              buttonLocale,
+              buttonSizeMode
+            });
+            
+            container.appendChild(button);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to initialize Google Pay:', error);
+        if (onError) {
+          onError(error as Error);
+        }
+      }
+    };
+
+    initializeGooglePay();
+  }, [
+    isReady,
+    isEligible,
+    config,
+    environment,
+    containerId,
+    buttonType,
+    buttonColor,
+    buttonLocale,
+    buttonSizeMode,
+    onPaymentAuthorized,
+    onGooglePayButtonClick,
+    onError
+  ]);
+
+  if (!isEligible) {
+    return null;
+  }
+
+  return (
+    <div 
+      id={containerId} 
+      className={className}
+      style={{ minHeight: '45px' }}
+    />
+  );
+}

--- a/packages/react/src/components/PayLaterButton.tsx
+++ b/packages/react/src/components/PayLaterButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PayPalButtonProps } from './PayPalButton';
+
+/**
+ * Pay Later button component
+ */
+export function PayLaterButton(props: PayPalButtonProps) {
+  return (
+    <paypal-pay-later-button
+      {...props}
+      data-payment-method="paylater"
+    />
+  );
+}

--- a/packages/react/src/components/PayPalButton.tsx
+++ b/packages/react/src/components/PayPalButton.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import { usePaymentSession } from '../hooks/usePaymentSession';
+import {
+  PaymentSessionOptions,
+  ButtonStyle,
+  PaymentMethod,
+  StartSessionOptions,
+  OrderPromise
+} from '@paypal-v6/types';
+
+/**
+ * PayPal button props
+ */
+export interface PayPalButtonProps {
+  /** Create order function */
+  createOrder: () => Promise<OrderPromise>;
+  
+  /** Payment session options */
+  sessionOptions?: PaymentSessionOptions;
+  
+  /** Start session options */
+  startOptions?: StartSessionOptions;
+  
+  /** Button style */
+  style?: ButtonStyle;
+  
+  /** Button type */
+  type?: 'pay' | 'buynow' | 'checkout' | 'donate' | 'subscribe';
+  
+  /** Disabled state */
+  disabled?: boolean;
+  
+  /** Custom class name */
+  className?: string;
+  
+  /** Button ID */
+  id?: string;
+  
+  /** Click handler (called before payment) */
+  onClick?: () => void | Promise<void>;
+  
+  /** Whether to show button immediately or wait for eligibility */
+  forceShow?: boolean;
+  
+  /** Loading state */
+  loading?: boolean;
+  
+  /** Custom loading component */
+  loadingComponent?: React.ReactNode;
+}
+
+/**
+ * PayPal button component
+ */
+export function PayPalButton({
+  createOrder,
+  sessionOptions = {},
+  startOptions = { presentationMode: 'auto' },
+  style,
+  type = 'pay',
+  disabled = false,
+  className,
+  id,
+  onClick,
+  forceShow = false,
+  loading = false,
+  loadingComponent
+}: PayPalButtonProps) {
+  const { isReady, eligibleMethods } = usePayPalSDK();
+  const { createSession, isSessionActive } = usePaymentSession(PaymentMethod.PAYPAL);
+  const [isEligible, setIsEligible] = useState<boolean>(forceShow);
+  const [isProcessing, setIsProcessing] = useState<boolean>(false);
+  const buttonRef = useRef<HTMLElement | null>(null);
+
+  /**
+   * Check eligibility
+   */
+  useEffect(() => {
+    if (eligibleMethods && !forceShow) {
+      setIsEligible(eligibleMethods.isEligible('paypal'));
+    }
+  }, [eligibleMethods, forceShow]);
+
+  /**
+   * Handle button click
+   */
+  const handleClick = useCallback(async () => {
+    if (disabled || isProcessing || isSessionActive) {
+      return;
+    }
+
+    try {
+      setIsProcessing(true);
+
+      // Call custom onClick if provided
+      if (onClick) {
+        await onClick();
+      }
+
+      // Create payment session
+      const session = createSession(sessionOptions);
+      
+      // Start payment flow
+      const orderPromise = createOrder();
+      await session.start(startOptions, orderPromise);
+      
+    } catch (error) {
+      console.error('PayPal payment failed:', error);
+      
+      // Call onError if provided in session options
+      if (sessionOptions.onError) {
+        sessionOptions.onError(error as Error);
+      }
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [
+    disabled,
+    isProcessing,
+    isSessionActive,
+    onClick,
+    createSession,
+    sessionOptions,
+    createOrder,
+    startOptions
+  ]);
+
+  /**
+   * Set up native button element
+   */
+  useEffect(() => {
+    if (buttonRef.current && isReady && isEligible) {
+      // Set button properties
+      const button = buttonRef.current as any;
+      
+      if (style?.color) button.color = style.color;
+      if (style?.shape) button.shape = style.shape;
+      if (style?.size) button.size = style.size;
+      if (style?.label) button.label = style.label;
+      if (style?.height) button.height = style.height;
+      if (type) button.type = type;
+    }
+  }, [isReady, isEligible, style, type]);
+
+  // Don't render if not eligible (unless forced)
+  if (!isEligible && !forceShow) {
+    return null;
+  }
+
+  // Show loading state
+  if (loading || !isReady) {
+    if (loadingComponent) {
+      return <>{loadingComponent}</>;
+    }
+    return (
+      <div className={className} style={{ textAlign: 'center', padding: '10px' }}>
+        Loading PayPal...
+      </div>
+    );
+  }
+
+  return (
+    <paypal-button
+      ref={buttonRef}
+      id={id}
+      className={className}
+      type={type}
+      onClick={handleClick}
+      disabled={disabled || isProcessing}
+      style={{
+        opacity: disabled || isProcessing ? 0.6 : 1,
+        cursor: disabled || isProcessing ? 'not-allowed' : 'pointer',
+        ...((style as any)?.customStyle || {})
+      }}
+    />
+  );
+}

--- a/packages/react/src/components/PayPalCreditButton.tsx
+++ b/packages/react/src/components/PayPalCreditButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PayPalButtonProps } from './PayPalButton';
+
+/**
+ * PayPal Credit button component
+ */
+export function PayPalCreditButton(props: PayPalButtonProps) {
+  return (
+    <paypal-credit-button
+      {...props}
+      data-payment-method="credit"
+    />
+  );
+}

--- a/packages/react/src/components/PayPalMessages.tsx
+++ b/packages/react/src/components/PayPalMessages.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useRef } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import { MessagesConfig } from '@paypal-v6/types';
+
+/**
+ * PayPal Messages props
+ */
+export interface PayPalMessagesProps extends MessagesConfig {
+  /** Custom class name */
+  className?: string;
+  
+  /** Container style */
+  containerStyle?: React.CSSProperties;
+}
+
+/**
+ * PayPal Messages component
+ */
+export function PayPalMessages({
+  amount,
+  currency,
+  style,
+  placement = 'payment',
+  offer,
+  buyerCountry,
+  ignoreCache,
+  onClick,
+  onApply,
+  onRender,
+  className,
+  containerStyle
+}: PayPalMessagesProps) {
+  const { isReady } = usePayPalSDK();
+  const messagesRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isReady || !messagesRef.current) {
+      return;
+    }
+
+    const messages = messagesRef.current as any;
+
+    // Set properties
+    if (amount !== undefined) messages.amount = amount;
+    if (currency) messages.currency = currency;
+    if (placement) messages.placement = placement;
+    if (offer) messages.offer = offer;
+    if (buyerCountry) messages.buyerCountry = buyerCountry;
+    if (ignoreCache !== undefined) messages.ignoreCache = ignoreCache;
+
+    // Set style
+    if (style) {
+      if (style.layout) messages.layout = style.layout;
+      if (style.logo) {
+        messages.logoType = style.logo.type;
+        messages.logoPosition = style.logo.position;
+      }
+      if (style.text) {
+        messages.textColor = style.text.color;
+        messages.textSize = style.text.size;
+        messages.textAlign = style.text.align;
+      }
+      if (style.color) messages.color = style.color;
+      if (style.ratio) messages.ratio = style.ratio;
+    }
+
+    // Set event handlers
+    if (onClick) {
+      messages.addEventListener('click', onClick);
+    }
+    if (onApply) {
+      messages.addEventListener('apply', onApply);
+    }
+    if (onRender) {
+      messages.addEventListener('render', onRender);
+    }
+
+    // Cleanup
+    return () => {
+      if (onClick) {
+        messages.removeEventListener('click', onClick);
+      }
+      if (onApply) {
+        messages.removeEventListener('apply', onApply);
+      }
+      if (onRender) {
+        messages.removeEventListener('render', onRender);
+      }
+    };
+  }, [
+    isReady,
+    amount,
+    currency,
+    style,
+    placement,
+    offer,
+    buyerCountry,
+    ignoreCache,
+    onClick,
+    onApply,
+    onRender
+  ]);
+
+  if (!isReady) {
+    return null;
+  }
+
+  return (
+    <div className={className} style={containerStyle}>
+      <paypal-messages ref={messagesRef} />
+    </div>
+  );
+}

--- a/packages/react/src/components/PaymentMethodSelector.tsx
+++ b/packages/react/src/components/PaymentMethodSelector.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useCallback } from 'react';
+import { useEligibleMethods } from '../hooks/useEligibleMethods';
+import { PaymentMethod } from '@paypal-v6/types';
+import { PayPalButton } from './PayPalButton';
+import { VenmoButton } from './VenmoButton';
+import { PayLaterButton } from './PayLaterButton';
+import { PayPalCreditButton } from './PayPalCreditButton';
+import { GooglePayButton } from './GooglePayButton';
+import { ApplePayButton } from './ApplePayButton';
+
+/**
+ * Payment method selector props
+ */
+export interface PaymentMethodSelectorProps {
+  /** Available payment methods to show */
+  methods?: PaymentMethod[];
+  
+  /** Create order function */
+  createOrder: () => Promise<{ orderId: string }>;
+  
+  /** Callback on payment success */
+  onSuccess?: (data: any) => void;
+  
+  /** Callback on payment error */
+  onError?: (error: Error) => void;
+  
+  /** Callback on payment cancel */
+  onCancel?: () => void;
+  
+  /** Layout direction */
+  layout?: 'vertical' | 'horizontal';
+  
+  /** Gap between buttons */
+  gap?: number;
+  
+  /** Custom class name */
+  className?: string;
+  
+  /** Show only eligible methods */
+  showOnlyEligible?: boolean;
+  
+  /** Amount for Google Pay/Apple Pay */
+  amount?: string;
+  
+  /** Currency code */
+  currency?: string;
+}
+
+/**
+ * Payment method selector component
+ */
+export function PaymentMethodSelector({
+  methods = [
+    PaymentMethod.PAYPAL,
+    PaymentMethod.VENMO,
+    PaymentMethod.PAYLATER,
+    PaymentMethod.CREDIT,
+    PaymentMethod.GOOGLE_PAY,
+    PaymentMethod.APPLE_PAY
+  ],
+  createOrder,
+  onSuccess,
+  onError,
+  onCancel,
+  layout = 'vertical',
+  gap = 12,
+  className,
+  showOnlyEligible = true,
+  amount = '10.00',
+  currency = 'USD'
+}: PaymentMethodSelectorProps) {
+  const { isEligible } = useEligibleMethods();
+  const [selectedMethod, setSelectedMethod] = useState<PaymentMethod | null>(null);
+
+  /**
+   * Check if method should be shown
+   */
+  const shouldShowMethod = useCallback((method: PaymentMethod): boolean => {
+    if (!showOnlyEligible) {
+      return true;
+    }
+    return isEligible(method);
+  }, [showOnlyEligible, isEligible]);
+
+  /**
+   * Common session options
+   */
+  const sessionOptions = {
+    onApprove: async (data: any) => {
+      setSelectedMethod(null);
+      if (onSuccess) {
+        onSuccess(data);
+      }
+    },
+    onCancel: () => {
+      setSelectedMethod(null);
+      if (onCancel) {
+        onCancel();
+      }
+    },
+    onError: (error: Error) => {
+      setSelectedMethod(null);
+      if (onError) {
+        onError(error);
+      }
+    }
+  };
+
+  /**
+   * Container styles
+   */
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: layout === 'vertical' ? 'column' : 'row',
+    gap: `${gap}px`,
+    flexWrap: layout === 'horizontal' ? 'wrap' : undefined
+  };
+
+  return (
+    <div className={className} style={containerStyle}>
+      {methods.includes(PaymentMethod.PAYPAL) && shouldShowMethod(PaymentMethod.PAYPAL) && (
+        <PayPalButton
+          createOrder={createOrder}
+          sessionOptions={sessionOptions}
+          onClick={() => setSelectedMethod(PaymentMethod.PAYPAL)}
+          disabled={selectedMethod !== null && selectedMethod !== PaymentMethod.PAYPAL}
+        />
+      )}
+      
+      {methods.includes(PaymentMethod.VENMO) && shouldShowMethod(PaymentMethod.VENMO) && (
+        <VenmoButton
+          createOrder={createOrder}
+          sessionOptions={sessionOptions}
+          onClick={() => setSelectedMethod(PaymentMethod.VENMO)}
+          disabled={selectedMethod !== null && selectedMethod !== PaymentMethod.VENMO}
+        />
+      )}
+      
+      {methods.includes(PaymentMethod.PAYLATER) && shouldShowMethod(PaymentMethod.PAYLATER) && (
+        <PayLaterButton
+          createOrder={createOrder}
+          sessionOptions={sessionOptions}
+          onClick={() => setSelectedMethod(PaymentMethod.PAYLATER)}
+          disabled={selectedMethod !== null && selectedMethod !== PaymentMethod.PAYLATER}
+        />
+      )}
+      
+      {methods.includes(PaymentMethod.CREDIT) && shouldShowMethod(PaymentMethod.CREDIT) && (
+        <PayPalCreditButton
+          createOrder={createOrder}
+          sessionOptions={sessionOptions}
+          onClick={() => setSelectedMethod(PaymentMethod.CREDIT)}
+          disabled={selectedMethod !== null && selectedMethod !== PaymentMethod.CREDIT}
+        />
+      )}
+      
+      {methods.includes(PaymentMethod.GOOGLE_PAY) && shouldShowMethod(PaymentMethod.GOOGLE_PAY) && (
+        <GooglePayButton
+          amount={amount}
+          currency={currency}
+          createOrder={async () => ({ id: (await createOrder()).orderId })}
+          captureOrder={async (orderId) => ({ orderId })}
+          onSuccess={onSuccess}
+          onError={onError}
+          onCancel={onCancel}
+        />
+      )}
+      
+      {methods.includes(PaymentMethod.APPLE_PAY) && shouldShowMethod(PaymentMethod.APPLE_PAY) && (
+        <ApplePayButton
+          amount={amount}
+          currency={currency}
+          createOrder={createOrder}
+          sessionOptions={sessionOptions}
+          disabled={selectedMethod !== null && selectedMethod !== PaymentMethod.APPLE_PAY}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/components/PaymentModal.tsx
+++ b/packages/react/src/components/PaymentModal.tsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useRef } from 'react';
+
+/**
+ * Payment modal props
+ */
+export interface PaymentModalProps {
+  /** Whether modal is open */
+  isOpen: boolean;
+  
+  /** Close handler */
+  onClose: () => void;
+  
+  /** Modal title */
+  title?: string;
+  
+  /** Children content */
+  children: React.ReactNode;
+  
+  /** Custom class name */
+  className?: string;
+  
+  /** Overlay class name */
+  overlayClassName?: string;
+  
+  /** Close on overlay click */
+  closeOnOverlayClick?: boolean;
+  
+  /** Close on escape key */
+  closeOnEscape?: boolean;
+  
+  /** Show close button */
+  showCloseButton?: boolean;
+  
+  /** Max width */
+  maxWidth?: string | number;
+  
+  /** Custom styles */
+  style?: React.CSSProperties;
+}
+
+/**
+ * Payment modal component
+ */
+export function PaymentModal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  className,
+  overlayClassName,
+  closeOnOverlayClick = true,
+  closeOnEscape = true,
+  showCloseButton = true,
+  maxWidth = '500px',
+  style
+}: PaymentModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Handle escape key
+   */
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, closeOnEscape, onClose]);
+
+  /**
+   * Handle overlay click
+   */
+  const handleOverlayClick = (event: React.MouseEvent) => {
+    if (closeOnOverlayClick && event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  /**
+   * Focus trap
+   */
+  useEffect(() => {
+    if (!isOpen || !modalRef.current) {
+      return;
+    }
+
+    const modal = modalRef.current;
+    const focusableElements = modal.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const firstElement = focusableElements[0] as HTMLElement;
+    const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+    // Focus first element
+    firstElement?.focus();
+
+    const handleTabKey = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      if (event.shiftKey) {
+        if (document.activeElement === firstElement) {
+          event.preventDefault();
+          lastElement?.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          event.preventDefault();
+          firstElement?.focus();
+        }
+      }
+    };
+
+    modal.addEventListener('keydown', handleTabKey);
+    return () => {
+      modal.removeEventListener('keydown', handleTabKey);
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  /**
+   * Default styles
+   */
+  const overlayStyles: React.CSSProperties = {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 9999
+  };
+
+  const modalStyles: React.CSSProperties = {
+    backgroundColor: 'white',
+    borderRadius: '8px',
+    padding: '24px',
+    maxWidth,
+    width: '90%',
+    maxHeight: '90vh',
+    overflow: 'auto',
+    position: 'relative',
+    boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+    ...style
+  };
+
+  const headerStyles: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '16px'
+  };
+
+  const titleStyles: React.CSSProperties = {
+    fontSize: '20px',
+    fontWeight: 'bold',
+    margin: 0
+  };
+
+  const closeButtonStyles: React.CSSProperties = {
+    background: 'none',
+    border: 'none',
+    fontSize: '24px',
+    cursor: 'pointer',
+    padding: '4px',
+    lineHeight: 1,
+    color: '#666'
+  };
+
+  return (
+    <div
+      className={overlayClassName}
+      style={overlayStyles}
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? 'modal-title' : undefined}
+    >
+      <div
+        ref={modalRef}
+        className={className}
+        style={modalStyles}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {(title || showCloseButton) && (
+          <div style={headerStyles}>
+            {title && (
+              <h2 id="modal-title" style={titleStyles}>
+                {title}
+              </h2>
+            )}
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                style={closeButtonStyles}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/VenmoButton.tsx
+++ b/packages/react/src/components/VenmoButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { usePaymentSession } from '../hooks/usePaymentSession';
+import { PaymentMethod } from '@paypal-v6/types';
+import { PayPalButtonProps } from './PayPalButton';
+
+/**
+ * Venmo button component
+ */
+export function VenmoButton(props: PayPalButtonProps) {
+  const { createSession, isSessionActive } = usePaymentSession(PaymentMethod.VENMO);
+  
+  // Venmo has different default styling
+  const venmoStyle = {
+    ...props.style,
+    color: props.style?.color || 'blue'
+  };
+
+  return (
+    <venmo-button
+      {...props}
+      style={venmoStyle}
+      data-payment-method="venmo"
+    />
+  );
+}

--- a/packages/react/src/context/PayPalSDKContext.tsx
+++ b/packages/react/src/context/PayPalSDKContext.tsx
@@ -1,0 +1,283 @@
+import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
+import { PayPalSDK } from '@paypal-v6/core';
+import {
+  SdkInitOptions,
+  SdkState,
+  EligiblePaymentMethods,
+  ErrorCode,
+  PayPalSdkError
+} from '@paypal-v6/types';
+
+/**
+ * PayPal SDK context value
+ */
+interface PayPalSDKContextValue {
+  /** SDK instance */
+  sdk: PayPalSDK | null;
+  
+  /** Current SDK state */
+  state: SdkState;
+  
+  /** Loading state */
+  isLoading: boolean;
+  
+  /** Ready state */
+  isReady: boolean;
+  
+  /** Error if any */
+  error: PayPalSdkError | null;
+  
+  /** Eligible payment methods */
+  eligibleMethods: EligiblePaymentMethods | null;
+  
+  /** Initialize SDK manually */
+  initialize: () => Promise<void>;
+  
+  /** Reset SDK */
+  reset: () => Promise<void>;
+  
+  /** Find eligible payment methods */
+  findEligibleMethods: (options?: any) => Promise<EligiblePaymentMethods | null>;
+}
+
+/**
+ * PayPal SDK context
+ */
+const PayPalSDKContext = createContext<PayPalSDKContextValue | null>(null);
+
+/**
+ * PayPal SDK provider props
+ */
+export interface PayPalSDKProviderProps {
+  /** SDK configuration */
+  config: SdkInitOptions;
+  
+  /** Children components */
+  children: React.ReactNode;
+  
+  /** Whether to defer SDK loading */
+  deferLoading?: boolean;
+  
+  /** Loading component */
+  loadingComponent?: React.ReactNode;
+  
+  /** Error component */
+  errorComponent?: (error: PayPalSdkError) => React.ReactNode;
+  
+  /** Callback when SDK is ready */
+  onReady?: () => void;
+  
+  /** Callback on error */
+  onError?: (error: PayPalSdkError) => void;
+}
+
+/**
+ * PayPal SDK provider component
+ */
+export function PayPalSDKProvider({
+  config,
+  children,
+  deferLoading = false,
+  loadingComponent,
+  errorComponent,
+  onReady,
+  onError
+}: PayPalSDKProviderProps) {
+  const [sdk, setSdk] = useState<PayPalSDK | null>(null);
+  const [state, setState] = useState<SdkState>(SdkState.NOT_INITIALIZED);
+  const [error, setError] = useState<PayPalSdkError | null>(null);
+  const [eligibleMethods, setEligibleMethods] = useState<EligiblePaymentMethods | null>(null);
+  
+  const sdkRef = useRef<PayPalSDK | null>(null);
+  const initPromiseRef = useRef<Promise<void> | null>(null);
+
+  /**
+   * Initialize SDK
+   */
+  const initialize = useCallback(async () => {
+    // Prevent multiple simultaneous initializations
+    if (initPromiseRef.current) {
+      return initPromiseRef.current;
+    }
+
+    // Check if already initialized
+    if (sdkRef.current && state === SdkState.READY) {
+      return Promise.resolve();
+    }
+
+    const initPromise = (async () => {
+      try {
+        setState(SdkState.LOADING);
+        setError(null);
+
+        // Create SDK instance with configuration
+        const sdkInstance = PayPalSDK.getInstance({
+          ...config,
+          autoLoad: false // We'll control loading manually
+        });
+
+        // Set up event listeners
+        const events = sdkInstance.getEvents();
+        
+        events.on('ready', () => {
+          setState(SdkState.READY);
+          if (onReady) {
+            onReady();
+          }
+        });
+
+        events.on('error', (event) => {
+          const sdkError = event.payload as PayPalSdkError;
+          setError(sdkError);
+          setState(SdkState.ERROR);
+          if (onError) {
+            onError(sdkError);
+          }
+        });
+
+        // Initialize the SDK
+        await sdkInstance.initialize();
+        
+        sdkRef.current = sdkInstance;
+        setSdk(sdkInstance);
+        setState(sdkInstance.getState());
+
+        // Find eligible methods if currency is configured
+        if (config.currency) {
+          try {
+            const methods = await sdkInstance.findEligibleMethods({
+              currencyCode: config.currency,
+              countryCode: config.buyerCountry
+            });
+            setEligibleMethods(methods);
+          } catch (err) {
+            console.warn('Failed to find eligible payment methods:', err);
+          }
+        }
+
+      } catch (err) {
+        const sdkError = err instanceof PayPalSdkError 
+          ? err 
+          : new PayPalSdkError(
+              ErrorCode.SDK_LOAD_FAILED,
+              'Failed to initialize PayPal SDK',
+              { originalError: err as Error }
+            );
+        
+        setError(sdkError);
+        setState(SdkState.ERROR);
+        
+        if (onError) {
+          onError(sdkError);
+        }
+        
+        throw sdkError;
+      } finally {
+        initPromiseRef.current = null;
+      }
+    })();
+
+    initPromiseRef.current = initPromise;
+    return initPromise;
+  }, [config, onReady, onError]);
+
+  /**
+   * Reset SDK
+   */
+  const reset = useCallback(async () => {
+    if (sdkRef.current) {
+      sdkRef.current.destroy();
+      sdkRef.current = null;
+      setSdk(null);
+    }
+    
+    setState(SdkState.NOT_INITIALIZED);
+    setError(null);
+    setEligibleMethods(null);
+    
+    await initialize();
+  }, [initialize]);
+
+  /**
+   * Find eligible payment methods
+   */
+  const findEligibleMethods = useCallback(async (options?: any) => {
+    if (!sdkRef.current) {
+      console.warn('SDK not initialized');
+      return null;
+    }
+
+    try {
+      const methods = await sdkRef.current.findEligibleMethods(options);
+      setEligibleMethods(methods);
+      return methods;
+    } catch (err) {
+      console.error('Failed to find eligible payment methods:', err);
+      return null;
+    }
+  }, []);
+
+  /**
+   * Initialize on mount unless deferred
+   */
+  useEffect(() => {
+    if (!deferLoading) {
+      initialize().catch(err => {
+        console.error('Failed to initialize PayPal SDK:', err);
+      });
+    }
+
+    // Cleanup on unmount
+    return () => {
+      if (sdkRef.current) {
+        // Don't destroy the singleton, just clean up listeners
+        const events = sdkRef.current.getEvents();
+        events.removeAllListeners();
+      }
+    };
+  }, []); // Only run once on mount
+
+  /**
+   * Context value
+   */
+  const contextValue: PayPalSDKContextValue = {
+    sdk,
+    state,
+    isLoading: state === SdkState.LOADING,
+    isReady: state === SdkState.READY,
+    error,
+    eligibleMethods,
+    initialize,
+    reset,
+    findEligibleMethods
+  };
+
+  // Show loading component if configured
+  if (state === SdkState.LOADING && loadingComponent) {
+    return <>{loadingComponent}</>;
+  }
+
+  // Show error component if configured
+  if (state === SdkState.ERROR && error && errorComponent) {
+    return <>{errorComponent(error)}</>;
+  }
+
+  return (
+    <PayPalSDKContext.Provider value={contextValue}>
+      {children}
+    </PayPalSDKContext.Provider>
+  );
+}
+
+/**
+ * Hook to use PayPal SDK context
+ */
+export function usePayPalSDK(): PayPalSDKContextValue {
+  const context = useContext(PayPalSDKContext);
+  
+  if (!context) {
+    throw new Error('usePayPalSDK must be used within a PayPalSDKProvider');
+  }
+  
+  return context;
+}

--- a/packages/react/src/hooks/useApplePay.ts
+++ b/packages/react/src/hooks/useApplePay.ts
@@ -1,0 +1,195 @@
+import { useEffect, useState, useCallback } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import {
+  ApplePaySession,
+  ApplePayConfig,
+  PaymentSessionOptions,
+  PayPalSdkError,
+  ErrorCode
+} from '@paypal-v6/types';
+
+/**
+ * Apple Pay hook return type
+ */
+export interface UseApplePayReturn {
+  /** Apple Pay session */
+  session: ApplePaySession | null;
+  
+  /** Apple Pay configuration */
+  config: ApplePayConfig | null;
+  
+  /** Whether Apple Pay is eligible */
+  isEligible: boolean;
+  
+  /** Whether Apple Pay is supported in browser */
+  isSupported: boolean;
+  
+  /** Create a new Apple Pay session */
+  createSession: (options?: PaymentSessionOptions) => ApplePaySession;
+  
+  /** Get Apple Pay configuration */
+  getConfig: () => Promise<ApplePayConfig | null>;
+  
+  /** Validate merchant */
+  validateMerchant: (validationURL: string) => Promise<any>;
+  
+  /** Loading state */
+  isLoading: boolean;
+  
+  /** Error if any */
+  error: Error | null;
+}
+
+/**
+ * Hook for Apple Pay integration
+ */
+export function useApplePay(): UseApplePayReturn {
+  const { sdk, isReady, eligibleMethods } = usePayPalSDK();
+  const [session, setSession] = useState<ApplePaySession | null>(null);
+  const [config, setConfig] = useState<ApplePayConfig | null>(null);
+  const [isEligible, setIsEligible] = useState(false);
+  const [isSupported, setIsSupported] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  /**
+   * Check Apple Pay support
+   */
+  useEffect(() => {
+    if (typeof window !== 'undefined' && (window as any).ApplePaySession) {
+      // Check if Apple Pay is available
+      const applePayAvailable = (window as any).ApplePaySession.canMakePayments();
+      setIsSupported(applePayAvailable);
+    }
+  }, []);
+
+  /**
+   * Check eligibility
+   */
+  useEffect(() => {
+    if (eligibleMethods) {
+      setIsEligible(eligibleMethods.isEligible('applepay'));
+    }
+  }, [eligibleMethods]);
+
+  /**
+   * Create Apple Pay session
+   */
+  const createSession = useCallback((options: PaymentSessionOptions = {}): ApplePaySession => {
+    if (!sdk || !isReady) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'PayPal SDK is not ready'
+      );
+    }
+
+    if (!isEligible) {
+      throw new PayPalSdkError(
+        ErrorCode.INVALID_PAYMENT_METHOD,
+        'Apple Pay is not eligible for this merchant'
+      );
+    }
+
+    if (!isSupported) {
+      throw new PayPalSdkError(
+        ErrorCode.DEVICE_NOT_SUPPORTED,
+        'Apple Pay is not supported on this device'
+      );
+    }
+
+    try {
+      const applePaySession = sdk.createApplePaySession(options);
+      setSession(applePaySession);
+      return applePaySession;
+    } catch (err) {
+      const sdkError = err instanceof PayPalSdkError
+        ? err
+        : new PayPalSdkError(
+            ErrorCode.SESSION_NOT_FOUND,
+            'Failed to create Apple Pay session',
+            { originalError: err as Error }
+          );
+      setError(sdkError);
+      throw sdkError;
+    }
+  }, [sdk, isReady, isEligible, isSupported]);
+
+  /**
+   * Get Apple Pay configuration
+   */
+  const getConfig = useCallback(async (): Promise<ApplePayConfig | null> => {
+    if (!session) {
+      const newSession = createSession();
+      if (!newSession) {
+        return null;
+      }
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const applePayConfig = await (session || createSession()).getApplePayConfig();
+      setConfig(applePayConfig);
+      return applePayConfig;
+    } catch (err) {
+      setError(err as Error);
+      console.error('Failed to get Apple Pay config:', err);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [session, createSession]);
+
+  /**
+   * Validate merchant
+   */
+  const validateMerchant = useCallback(async (validationURL: string): Promise<any> => {
+    if (!session) {
+      throw new PayPalSdkError(
+        ErrorCode.SESSION_NOT_FOUND,
+        'Apple Pay session not initialized'
+      );
+    }
+
+    try {
+      return await session.validateMerchant(validationURL);
+    } catch (err) {
+      const sdkError = err instanceof PayPalSdkError
+        ? err
+        : new PayPalSdkError(
+            ErrorCode.PAYMENT_FAILED,
+            'Failed to validate merchant',
+            { originalError: err as Error }
+          );
+      throw sdkError;
+    }
+  }, [session]);
+
+  /**
+   * Initialize Apple Pay session and config
+   */
+  useEffect(() => {
+    if (isReady && isEligible && isSupported && !session) {
+      try {
+        const applePaySession = createSession();
+        applePaySession.getApplePayConfig().then(setConfig).catch(setError);
+      } catch (err) {
+        // Session creation might fail if components not loaded
+        console.debug('Apple Pay session creation deferred:', err);
+      }
+    }
+  }, [isReady, isEligible, isSupported, session, createSession]);
+
+  return {
+    session,
+    config,
+    isEligible,
+    isSupported,
+    createSession,
+    getConfig,
+    validateMerchant,
+    isLoading,
+    error
+  };
+}

--- a/packages/react/src/hooks/useEligibleMethods.ts
+++ b/packages/react/src/hooks/useEligibleMethods.ts
@@ -1,0 +1,99 @@
+import { useEffect, useState, useCallback } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import {
+  EligiblePaymentMethods,
+  FindEligibleMethodsOptions,
+  PaymentMethod
+} from '@paypal-v6/types';
+
+/**
+ * Eligible methods hook return type
+ */
+export interface UseEligibleMethodsReturn {
+  /** Eligible payment methods */
+  eligibleMethods: EligiblePaymentMethods | null;
+  
+  /** Check if a specific method is eligible */
+  isEligible: (method: PaymentMethod | string) => boolean;
+  
+  /** Get all eligible methods */
+  allEligibleMethods: string[];
+  
+  /** Refresh eligible methods */
+  refresh: (options?: FindEligibleMethodsOptions) => Promise<void>;
+  
+  /** Loading state */
+  isLoading: boolean;
+  
+  /** Error if any */
+  error: Error | null;
+}
+
+/**
+ * Hook for managing eligible payment methods
+ */
+export function useEligibleMethods(
+  options?: FindEligibleMethodsOptions
+): UseEligibleMethodsReturn {
+  const { sdk, isReady, eligibleMethods: contextMethods } = usePayPalSDK();
+  const [eligibleMethods, setEligibleMethods] = useState<EligiblePaymentMethods | null>(contextMethods);
+  const [allEligibleMethods, setAllEligibleMethods] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  /**
+   * Check if a method is eligible
+   */
+  const isEligible = useCallback((method: PaymentMethod | string): boolean => {
+    if (!eligibleMethods) {
+      return false;
+    }
+    return eligibleMethods.isEligible(method);
+  }, [eligibleMethods]);
+
+  /**
+   * Refresh eligible methods
+   */
+  const refresh = useCallback(async (refreshOptions?: FindEligibleMethodsOptions) => {
+    if (!sdk || !isReady) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const methods = await sdk.findEligibleMethods(refreshOptions || options);
+      if (methods) {
+        setEligibleMethods(methods);
+        setAllEligibleMethods(methods.getAllEligible());
+      }
+    } catch (err) {
+      setError(err as Error);
+      console.error('Failed to find eligible methods:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sdk, isReady, options]);
+
+  /**
+   * Initial load and updates
+   */
+  useEffect(() => {
+    if (contextMethods) {
+      setEligibleMethods(contextMethods);
+      setAllEligibleMethods(contextMethods.getAllEligible());
+    } else if (isReady && !eligibleMethods && !isLoading) {
+      refresh();
+    }
+  }, [contextMethods, isReady, eligibleMethods, isLoading, refresh]);
+
+  return {
+    eligibleMethods,
+    isEligible,
+    allEligibleMethods,
+    refresh,
+    isLoading,
+    error
+  };
+}

--- a/packages/react/src/hooks/useGooglePay.ts
+++ b/packages/react/src/hooks/useGooglePay.ts
@@ -1,0 +1,156 @@
+import { useEffect, useState, useCallback } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import {
+  GooglePaySession,
+  GooglePayConfig,
+  PayPalSdkError,
+  ErrorCode
+} from '@paypal-v6/types';
+
+/**
+ * Google Pay hook return type
+ */
+export interface UseGooglePayReturn {
+  /** Google Pay session */
+  session: GooglePaySession | null;
+  
+  /** Google Pay configuration */
+  config: GooglePayConfig | null;
+  
+  /** Whether Google Pay is eligible */
+  isEligible: boolean;
+  
+  /** Whether Google Pay is supported in browser */
+  isSupported: boolean;
+  
+  /** Create a new Google Pay session */
+  createSession: () => GooglePaySession;
+  
+  /** Get Google Pay configuration */
+  getConfig: () => Promise<GooglePayConfig | null>;
+  
+  /** Loading state */
+  isLoading: boolean;
+  
+  /** Error if any */
+  error: Error | null;
+}
+
+/**
+ * Hook for Google Pay integration
+ */
+export function useGooglePay(): UseGooglePayReturn {
+  const { sdk, isReady, eligibleMethods } = usePayPalSDK();
+  const [session, setSession] = useState<GooglePaySession | null>(null);
+  const [config, setConfig] = useState<GooglePayConfig | null>(null);
+  const [isEligible, setIsEligible] = useState(false);
+  const [isSupported, setIsSupported] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  /**
+   * Check Google Pay support
+   */
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.google?.payments?.api) {
+      setIsSupported(true);
+    }
+  }, []);
+
+  /**
+   * Check eligibility
+   */
+  useEffect(() => {
+    if (eligibleMethods) {
+      setIsEligible(eligibleMethods.isEligible('googlepay'));
+    }
+  }, [eligibleMethods]);
+
+  /**
+   * Create Google Pay session
+   */
+  const createSession = useCallback((): GooglePaySession => {
+    if (!sdk || !isReady) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'PayPal SDK is not ready'
+      );
+    }
+
+    if (!isEligible) {
+      throw new PayPalSdkError(
+        ErrorCode.INVALID_PAYMENT_METHOD,
+        'Google Pay is not eligible for this merchant'
+      );
+    }
+
+    try {
+      const googlePaySession = sdk.createGooglePaySession();
+      setSession(googlePaySession);
+      return googlePaySession;
+    } catch (err) {
+      const sdkError = err instanceof PayPalSdkError
+        ? err
+        : new PayPalSdkError(
+            ErrorCode.SESSION_NOT_FOUND,
+            'Failed to create Google Pay session',
+            { originalError: err as Error }
+          );
+      setError(sdkError);
+      throw sdkError;
+    }
+  }, [sdk, isReady, isEligible]);
+
+  /**
+   * Get Google Pay configuration
+   */
+  const getConfig = useCallback(async (): Promise<GooglePayConfig | null> => {
+    if (!session) {
+      const newSession = createSession();
+      if (!newSession) {
+        return null;
+      }
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const googlePayConfig = await (session || createSession()).getGooglePayConfig();
+      setConfig(googlePayConfig);
+      return googlePayConfig;
+    } catch (err) {
+      setError(err as Error);
+      console.error('Failed to get Google Pay config:', err);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [session, createSession]);
+
+  /**
+   * Initialize Google Pay session and config
+   */
+  useEffect(() => {
+    if (isReady && isEligible && isSupported && !session) {
+      try {
+        const googlePaySession = createSession();
+        googlePaySession.getGooglePayConfig().then(setConfig).catch(setError);
+      } catch (err) {
+        // Session creation might fail if components not loaded
+        console.debug('Google Pay session creation deferred:', err);
+      }
+    }
+  }, [isReady, isEligible, isSupported, session, createSession]);
+
+  return {
+    session,
+    config,
+    isEligible,
+    isSupported,
+    createSession,
+    getConfig,
+    isLoading,
+    error
+  };
+}

--- a/packages/react/src/hooks/usePayPalSession.ts
+++ b/packages/react/src/hooks/usePayPalSession.ts
@@ -1,0 +1,9 @@
+import { usePaymentSession } from './usePaymentSession';
+import { PaymentMethod } from '@paypal-v6/types';
+
+/**
+ * Hook specifically for PayPal payment sessions
+ */
+export function usePayPalSession() {
+  return usePaymentSession(PaymentMethod.PAYPAL);
+}

--- a/packages/react/src/hooks/usePaymentSession.ts
+++ b/packages/react/src/hooks/usePaymentSession.ts
@@ -1,0 +1,139 @@
+import { useCallback, useState, useRef } from 'react';
+import { usePayPalSDK } from '../context/PayPalSDKContext';
+import {
+  PaymentMethod,
+  PaymentSessionOptions,
+  BasePaymentSession,
+  PayPalSdkError,
+  ErrorCode
+} from '@paypal-v6/types';
+
+/**
+ * Payment session hook return type
+ */
+export interface UsePaymentSessionReturn {
+  /** Create a new payment session */
+  createSession: (options?: PaymentSessionOptions) => BasePaymentSession;
+  
+  /** Current session instance */
+  session: BasePaymentSession | null;
+  
+  /** Whether a session is currently active */
+  isSessionActive: boolean;
+  
+  /** Cancel the current session */
+  cancelSession: () => void;
+  
+  /** Destroy the current session */
+  destroySession: () => void;
+  
+  /** Session error if any */
+  error: PayPalSdkError | null;
+}
+
+/**
+ * Hook for managing payment sessions
+ */
+export function usePaymentSession(
+  paymentMethod: PaymentMethod
+): UsePaymentSessionReturn {
+  const { sdk, isReady } = usePayPalSDK();
+  const [isSessionActive, setIsSessionActive] = useState(false);
+  const [error, setError] = useState<PayPalSdkError | null>(null);
+  const sessionRef = useRef<BasePaymentSession | null>(null);
+
+  /**
+   * Create a payment session
+   */
+  const createSession = useCallback((options: PaymentSessionOptions = {}) => {
+    if (!sdk || !isReady) {
+      throw new PayPalSdkError(
+        ErrorCode.SDK_NOT_INITIALIZED,
+        'PayPal SDK is not ready'
+      );
+    }
+
+    // Destroy existing session if any
+    if (sessionRef.current) {
+      sessionRef.current.destroy();
+    }
+
+    try {
+      let session: BasePaymentSession;
+
+      // Create session based on payment method
+      switch (paymentMethod) {
+        case PaymentMethod.PAYPAL:
+          session = sdk.createPayPalSession(options);
+          break;
+        case PaymentMethod.VENMO:
+          session = sdk.createVenmoSession(options);
+          break;
+        case PaymentMethod.PAYLATER:
+          session = sdk.createPayLaterSession(options);
+          break;
+        case PaymentMethod.CREDIT:
+          session = sdk.createCreditSession(options);
+          break;
+        default:
+          throw new PayPalSdkError(
+            ErrorCode.INVALID_PAYMENT_METHOD,
+            `Unsupported payment method: ${paymentMethod}`
+          );
+      }
+
+      sessionRef.current = session;
+      setIsSessionActive(true);
+      setError(null);
+
+      // Listen for session end
+      const events = sdk.getEvents();
+      const handleSessionEnd = () => {
+        setIsSessionActive(false);
+      };
+      events.once('session_ended', handleSessionEnd);
+
+      return session;
+    } catch (err) {
+      const sdkError = err instanceof PayPalSdkError
+        ? err
+        : new PayPalSdkError(
+            ErrorCode.SESSION_NOT_FOUND,
+            'Failed to create payment session',
+            { originalError: err as Error }
+          );
+      setError(sdkError);
+      throw sdkError;
+    }
+  }, [sdk, isReady, paymentMethod]);
+
+  /**
+   * Cancel the current session
+   */
+  const cancelSession = useCallback(() => {
+    if (sessionRef.current) {
+      sessionRef.current.cancel();
+      setIsSessionActive(false);
+    }
+  }, []);
+
+  /**
+   * Destroy the current session
+   */
+  const destroySession = useCallback(() => {
+    if (sessionRef.current) {
+      sessionRef.current.destroy();
+      sessionRef.current = null;
+      setIsSessionActive(false);
+    }
+  }, []);
+
+  return {
+    createSession,
+    session: sessionRef.current,
+    isSessionActive,
+    cancelSession,
+    destroySession,
+    error
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,27 @@
+// Context and Provider
+export { PayPalSDKProvider, usePayPalSDK } from './context/PayPalSDKContext';
+
+// Hooks
+export { usePayPalSession } from './hooks/usePayPalSession';
+export { useEligibleMethods } from './hooks/useEligibleMethods';
+export { usePaymentSession } from './hooks/usePaymentSession';
+export { useGooglePay } from './hooks/useGooglePay';
+export { useApplePay } from './hooks/useApplePay';
+
+// Components
+export { PayPalButton } from './components/PayPalButton';
+export { VenmoButton } from './components/VenmoButton';
+export { PayLaterButton } from './components/PayLaterButton';
+export { PayPalCreditButton } from './components/PayPalCreditButton';
+export { GooglePayButton } from './components/GooglePayButton';
+export { ApplePayButton } from './components/ApplePayButton';
+export { PayPalMessages } from './components/PayPalMessages';
+
+// Utility Components
+export { PaymentMethodSelector } from './components/PaymentMethodSelector';
+export { PaymentModal } from './components/PaymentModal';
+export { ErrorBoundary } from './components/ErrorBoundary';
+
+// Re-export types from core
+export * from '@paypal-v6/types';
+export type { PayPalSDK } from '@paypal-v6/core';

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  splitting: false,
+  external: ['react', 'react-dom', '@paypal-v6/core', '@paypal-v6/types'],
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@paypal-v6/types",
+  "version": "0.1.0",
+  "description": "TypeScript type definitions for PayPal v6 Web SDK",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "^5.8.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/types/src/callbacks.ts
+++ b/packages/types/src/callbacks.ts
@@ -1,0 +1,235 @@
+import type { PresentationMode } from './payment-methods';
+import type { Order } from './orders';
+
+/**
+ * Data passed to onApprove callback
+ */
+export interface OnApproveData {
+  /** Order ID */
+  orderId: string;
+  
+  /** Payer ID */
+  payerId?: string;
+  
+  /** Payment ID (for some payment methods) */
+  paymentId?: string;
+  
+  /** Billing token (for saved payment methods) */
+  billingToken?: string;
+  
+  /** Facilitator access token */
+  facilitatorAccessToken?: string;
+  
+  /** Payment source */
+  paymentSource?: string;
+}
+
+/**
+ * Data passed to onCancel callback
+ */
+export interface OnCancelData {
+  /** Order ID if available */
+  orderId?: string;
+}
+
+/**
+ * Data passed to onError callback
+ */
+export interface OnErrorData {
+  /** Error message */
+  message: string;
+  
+  /** Error code */
+  code?: string;
+  
+  /** Debug ID for PayPal support */
+  debugId?: string;
+  
+  /** Additional error details */
+  details?: any[];
+  
+  /** Order ID if available */
+  orderId?: string;
+}
+
+/**
+ * Data passed to onShippingChange callback
+ */
+export interface OnShippingChangeData {
+  /** Order ID */
+  orderId: string;
+  
+  /** Selected shipping option */
+  shippingOption?: {
+    id: string;
+    label: string;
+    amount: {
+      currencyCode: string;
+      value: string;
+    };
+  };
+  
+  /** Shipping address */
+  shippingAddress?: {
+    city?: string;
+    state?: string;
+    countryCode: string;
+    postalCode?: string;
+  };
+  
+  /** Updated order details */
+  orderDetails?: Partial<Order>;
+}
+
+/**
+ * Return type for onShippingChange callback
+ */
+export interface OnShippingChangeReturn {
+  /** Resolve the promise to continue */
+  resolve?: () => void;
+  
+  /** Reject the promise with an error */
+  reject?: (reason?: string) => void;
+  
+  /** Update the order with new details */
+  patch?: () => Promise<void>;
+}
+
+/**
+ * Data passed to onClick callback
+ */
+export interface OnClickData {
+  /** Funding source clicked */
+  fundingSource: string;
+}
+
+/**
+ * Payment session options
+ */
+export interface PaymentSessionOptions {
+  /** Called when the payment is approved */
+  onApprove?: (data: OnApproveData) => void | Promise<void>;
+  
+  /** Called when the payment is cancelled */
+  onCancel?: (data: OnCancelData) => void;
+  
+  /** Called when an error occurs */
+  onError?: (error: Error | OnErrorData) => void;
+  
+  /** Called when shipping address or option changes */
+  onShippingChange?: (data: OnShippingChangeData) => OnShippingChangeReturn | Promise<OnShippingChangeReturn>;
+  
+  /** Called when payment button is clicked */
+  onClick?: (data: OnClickData) => void | Promise<void>;
+  
+  /** Called before payment initialization */
+  onInit?: (data: any) => void | Promise<void>;
+  
+  /** Called when payment UI is closed */
+  onClose?: () => void;
+}
+
+/**
+ * Options for starting a payment session
+ */
+export interface StartSessionOptions {
+  /** Presentation mode for the payment UI */
+  presentationMode?: PresentationMode;
+  
+  /** Full page overlay configuration */
+  fullPageOverlay?: {
+    enabled?: boolean;
+    backgroundColor?: string;
+    opacity?: number;
+  };
+  
+  /** Parent element for inline presentation */
+  parentElement?: HTMLElement | string;
+  
+  /** Style configuration */
+  style?: {
+    height?: number;
+    width?: number;
+    borderRadius?: number;
+  };
+}
+
+/**
+ * Order promise passed to session start
+ */
+export interface OrderPromise {
+  orderId: string;
+}
+
+/**
+ * Payment session interface
+ */
+export interface PaymentSession {
+  /** Start the payment session */
+  start(
+    options: StartSessionOptions,
+    orderPromise: Promise<OrderPromise>
+  ): Promise<void>;
+  
+  /** Cancel the current session */
+  cancel(): void;
+  
+  /** Destroy the session and clean up */
+  destroy(): void;
+  
+  /** Check if session is active */
+  isActive(): boolean;
+}
+
+/**
+ * Event types for SDK events
+ */
+export enum SdkEventType {
+  READY = 'ready',
+  LOADED = 'loaded',
+  ERROR = 'error',
+  PAYMENT_APPROVED = 'payment_approved',
+  PAYMENT_CANCELLED = 'payment_cancelled',
+  PAYMENT_ERROR = 'payment_error',
+  SESSION_STARTED = 'session_started',
+  SESSION_ENDED = 'session_ended'
+}
+
+/**
+ * SDK event
+ */
+export interface SdkEvent {
+  /** Event type */
+  type: SdkEventType;
+  
+  /** Event payload */
+  payload?: any;
+  
+  /** Timestamp */
+  timestamp: number;
+}
+
+/**
+ * Event listener function
+ */
+export type EventListener = (event: SdkEvent) => void;
+
+/**
+ * Event emitter interface
+ */
+export interface EventEmitter {
+  /** Add event listener */
+  on(event: SdkEventType, listener: EventListener): void;
+  
+  /** Remove event listener */
+  off(event: SdkEventType, listener: EventListener): void;
+  
+  /** Add one-time event listener */
+  once(event: SdkEventType, listener: EventListener): void;
+  
+  /** Emit an event */
+  emit(event: SdkEventType, payload?: any): void;
+  
+  /** Remove all listeners for an event */
+  removeAllListeners(event?: SdkEventType): void;
+}

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -1,0 +1,188 @@
+/**
+ * SDK components that can be loaded
+ */
+export type Component = 
+  | 'paypal-payments'
+  | 'venmo-payments'
+  | 'googlepay-payments'
+  | 'applepay-payments'
+  | 'card-payments'
+  | 'ideal-payments'
+  | 'sepa-payments'
+  | 'bancontact-payments'
+  | 'giropay-payments'
+  | 'sofort-payments'
+  | 'eps-payments'
+  | 'mybank-payments'
+  | 'p24-payments'
+  | 'blik-payments'
+  | 'fastlane'
+  | 'messages';
+
+/**
+ * Page types for SDK initialization
+ */
+export type PageType =
+  | 'cart'
+  | 'checkout'
+  | 'home'
+  | 'mini-cart'
+  | 'product-details'
+  | 'product-listing'
+  | 'search-results'
+  | 'billing'
+  | 'payment'
+  | 'order-confirmation';
+
+/**
+ * Button style configuration
+ */
+export interface ButtonStyle {
+  /** Button color */
+  color?: 'gold' | 'blue' | 'black' | 'white' | 'silver';
+  
+  /** Button shape */
+  shape?: 'rect' | 'pill';
+  
+  /** Button size */
+  size?: 'small' | 'medium' | 'large' | 'responsive';
+  
+  /** Button label */
+  label?: 'paypal' | 'checkout' | 'buynow' | 'pay' | 'installment' | 'subscribe' | 'donate';
+  
+  /** Button layout */
+  layout?: 'vertical' | 'horizontal';
+  
+  /** Button height (25-55) */
+  height?: number;
+  
+  /** Show tagline */
+  tagline?: boolean;
+}
+
+/**
+ * PayPal button props for React/Vue components
+ */
+export interface PayPalButtonProps {
+  /** Button type */
+  type?: 'pay' | 'buynow' | 'checkout' | 'donate' | 'subscribe';
+  
+  /** Button style */
+  style?: ButtonStyle;
+  
+  /** Disabled state */
+  disabled?: boolean;
+  
+  /** Click handler */
+  onClick?: () => void;
+  
+  /** Custom class name */
+  className?: string;
+  
+  /** Custom ID */
+  id?: string;
+}
+
+/**
+ * Venmo button props
+ */
+export interface VenmoButtonProps extends PayPalButtonProps {
+  /** Venmo specific style */
+  style?: ButtonStyle & {
+    color?: 'blue' | 'white' | 'black';
+  };
+}
+
+/**
+ * Messages component configuration
+ */
+export interface MessagesConfig {
+  /** Amount for the message */
+  amount?: number | string;
+  
+  /** Currency */
+  currency?: string;
+  
+  /** Style configuration */
+  style?: {
+    layout?: 'text' | 'flex' | 'custom';
+    logo?: {
+      type?: 'primary' | 'alternative' | 'inline' | 'none';
+      position?: 'left' | 'right' | 'top';
+    };
+    text?: {
+      color?: 'black' | 'white' | 'monochrome' | 'grayscale';
+      size?: number;
+      align?: 'left' | 'center' | 'right';
+    };
+    color?: 'blue' | 'black' | 'white' | 'gray' | 'monochrome' | 'grayscale';
+    ratio?: '1x1' | '1x4' | '8x1' | '20x1' | 'custom';
+  };
+  
+  /** Placement on the page */
+  placement?: 'home' | 'category' | 'product' | 'cart' | 'payment';
+  
+  /** Offer type */
+  offer?: 'PAY_LATER_LONG_TERM' | 'PAY_LATER_SHORT_TERM' | 'PAY_LATER_PAY_IN_1';
+  
+  /** Buyer country */
+  buyerCountry?: string;
+  
+  /** Ignore cache */
+  ignoreCache?: boolean;
+  
+  /** On click handler */
+  onClick?: () => void;
+  
+  /** On apply handler */
+  onApply?: () => void;
+  
+  /** On render handler */
+  onRender?: () => void;
+}
+
+/**
+ * Fastlane component configuration
+ */
+export interface FastlaneConfig {
+  /** Show card form */
+  showCardForm?: boolean;
+  
+  /** Show saved cards */
+  showSavedCards?: boolean;
+  
+  /** Style configuration */
+  style?: {
+    root?: Record<string, string>;
+    input?: Record<string, string>;
+    button?: Record<string, string>;
+    label?: Record<string, string>;
+    error?: Record<string, string>;
+  };
+  
+  /** Locale */
+  locale?: string;
+  
+  /** Placeholder text */
+  placeholders?: {
+    cardNumber?: string;
+    expirationDate?: string;
+    cvv?: string;
+    postalCode?: string;
+  };
+}
+
+/**
+ * Custom element definitions for HTML
+ */
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'paypal-button': PayPalButtonProps & React.HTMLAttributes<HTMLElement>;
+      'venmo-button': VenmoButtonProps & React.HTMLAttributes<HTMLElement>;
+      'paypal-pay-later-button': PayPalButtonProps & React.HTMLAttributes<HTMLElement>;
+      'paypal-credit-button': PayPalButtonProps & React.HTMLAttributes<HTMLElement>;
+      'paypal-messages': MessagesConfig & React.HTMLAttributes<HTMLElement>;
+    }
+  }
+}

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1,0 +1,237 @@
+import type { Component, PageType } from './components';
+import type { RetryConfig, ErrorRecoveryConfig } from './errors';
+
+/**
+ * SDK environment
+ */
+export enum Environment {
+  SANDBOX = 'sandbox',
+  PRODUCTION = 'production',
+  LOCAL = 'local'
+}
+
+/**
+ * SDK configuration
+ */
+export interface SdkConfig {
+  /** Environment to use */
+  environment?: Environment;
+  
+  /** Client ID (for direct initialization) */
+  clientId?: string;
+  
+  /** Client token (for server-side initialization) */
+  clientToken?: string;
+  
+  /** Components to load */
+  components?: Component[];
+  
+  /** Page type */
+  pageType?: PageType;
+  
+  /** Locale */
+  locale?: string;
+  
+  /** Currency */
+  currency?: string;
+  
+  /** Buyer country */
+  buyerCountry?: string;
+  
+  /** Partner attribution ID */
+  partnerAttributionId?: string;
+  
+  /** Client metadata ID */
+  clientMetadataId?: string;
+  
+  /** Merchant ID */
+  merchantId?: string;
+  
+  /** Data attributes for the script tag */
+  dataAttributes?: Record<string, string>;
+  
+  /** Custom SDK URL */
+  sdkUrl?: string;
+  
+  /** SDK version to load */
+  version?: string;
+  
+  /** Debug mode */
+  debug?: boolean;
+  
+  /** Disable funding sources */
+  disableFunding?: string[];
+  
+  /** Enable funding sources */
+  enableFunding?: string[];
+  
+  /** Commit (true = "Pay Now", false = "Continue") */
+  commit?: boolean;
+  
+  /** Vault configuration */
+  vault?: boolean | {
+    /** Show vaulted payment methods */
+    showSavedPaymentMethods?: boolean;
+    
+    /** Allow vault without purchase */
+    allowVaultWithoutPurchase?: boolean;
+  };
+  
+  /** Intent */
+  intent?: 'capture' | 'authorize' | 'tokenize' | 'subscription';
+  
+  /** Enable 3D Secure */
+  enable3DS?: boolean;
+  
+  /** CSP nonce */
+  cspNonce?: string;
+  
+  /** Integration date (YYYY-MM-DD) */
+  integrationDate?: string;
+  
+  /** User ID token */
+  userIdToken?: string;
+  
+  /** SDK integration source */
+  sdkIntegrationSource?: string;
+}
+
+/**
+ * Logger configuration
+ */
+export interface LoggerConfig {
+  /** Enable logging */
+  enabled?: boolean;
+  
+  /** Log level */
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  
+  /** Custom logger implementation */
+  logger?: {
+    debug: (...args: any[]) => void;
+    info: (...args: any[]) => void;
+    warn: (...args: any[]) => void;
+    error: (...args: any[]) => void;
+  };
+  
+  /** Include timestamp in logs */
+  includeTimestamp?: boolean;
+  
+  /** Include stack traces */
+  includeStackTrace?: boolean;
+}
+
+/**
+ * Performance monitoring configuration
+ */
+export interface PerformanceConfig {
+  /** Enable performance monitoring */
+  enabled?: boolean;
+  
+  /** Sample rate (0-1) */
+  sampleRate?: number;
+  
+  /** Custom performance observer */
+  observer?: (metric: PerformanceMetric) => void;
+}
+
+/**
+ * Performance metric
+ */
+export interface PerformanceMetric {
+  /** Metric name */
+  name: string;
+  
+  /** Metric value */
+  value: number;
+  
+  /** Unit of measurement */
+  unit?: string;
+  
+  /** Additional tags */
+  tags?: Record<string, string>;
+  
+  /** Timestamp */
+  timestamp: number;
+}
+
+/**
+ * Complete SDK initialization options
+ */
+export interface SdkInitOptions extends SdkConfig {
+  /** Logger configuration */
+  logger?: LoggerConfig;
+  
+  /** Performance monitoring */
+  performance?: PerformanceConfig;
+  
+  /** Retry configuration */
+  retry?: RetryConfig;
+  
+  /** Error recovery configuration */
+  errorRecovery?: ErrorRecoveryConfig;
+  
+  /** Auto-load SDK on initialization */
+  autoLoad?: boolean;
+  
+  /** Timeout for SDK loading (ms) */
+  loadTimeout?: number;
+  
+  /** Callbacks */
+  callbacks?: {
+    /** Called when SDK is loaded */
+    onLoad?: () => void;
+    
+    /** Called when SDK is ready */
+    onReady?: () => void;
+    
+    /** Called on SDK error */
+    onError?: (error: Error) => void;
+  };
+}
+
+/**
+ * SDK metadata
+ */
+export interface SdkMetadata {
+  /** SDK version */
+  version: string;
+  
+  /** Build timestamp */
+  buildTime?: string;
+  
+  /** Git commit hash */
+  commit?: string;
+  
+  /** Environment */
+  environment: Environment;
+  
+  /** Loaded components */
+  components: Component[];
+  
+  /** Supported features */
+  features?: string[];
+}
+
+/**
+ * SDK state
+ */
+export enum SdkState {
+  /** Not initialized */
+  NOT_INITIALIZED = 'NOT_INITIALIZED',
+  
+  /** Loading */
+  LOADING = 'LOADING',
+  
+  /** Loaded but not ready */
+  LOADED = 'LOADED',
+  
+  /** Ready to use */
+  READY = 'READY',
+  
+  /** Error state */
+  ERROR = 'ERROR',
+  
+  /** Destroyed */
+  DESTROYED = 'DESTROYED'
+}

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -1,0 +1,168 @@
+/**
+ * PayPal SDK error codes
+ */
+export enum ErrorCode {
+  // Initialization errors
+  SDK_LOAD_FAILED = 'SDK_LOAD_FAILED',
+  SDK_ALREADY_LOADED = 'SDK_ALREADY_LOADED',
+  INVALID_CLIENT_TOKEN = 'INVALID_CLIENT_TOKEN',
+  INVALID_CONFIGURATION = 'INVALID_CONFIGURATION',
+  COMPONENT_NOT_LOADED = 'COMPONENT_NOT_LOADED',
+  
+  // Payment errors
+  PAYMENT_CANCELLED = 'PAYMENT_CANCELLED',
+  PAYMENT_FAILED = 'PAYMENT_FAILED',
+  PAYMENT_NOT_APPROVED = 'PAYMENT_NOT_APPROVED',
+  ORDER_NOT_FOUND = 'ORDER_NOT_FOUND',
+  ORDER_ALREADY_CAPTURED = 'ORDER_ALREADY_CAPTURED',
+  
+  // Network errors
+  NETWORK_ERROR = 'NETWORK_ERROR',
+  TIMEOUT_ERROR = 'TIMEOUT_ERROR',
+  SERVER_ERROR = 'SERVER_ERROR',
+  
+  // Validation errors
+  INVALID_AMOUNT = 'INVALID_AMOUNT',
+  INVALID_CURRENCY = 'INVALID_CURRENCY',
+  INVALID_COUNTRY = 'INVALID_COUNTRY',
+  INVALID_PAYMENT_METHOD = 'INVALID_PAYMENT_METHOD',
+  
+  // Session errors
+  SESSION_EXPIRED = 'SESSION_EXPIRED',
+  SESSION_ALREADY_ACTIVE = 'SESSION_ALREADY_ACTIVE',
+  SESSION_NOT_FOUND = 'SESSION_NOT_FOUND',
+  
+  // Browser/device errors
+  BROWSER_NOT_SUPPORTED = 'BROWSER_NOT_SUPPORTED',
+  POPUP_BLOCKED = 'POPUP_BLOCKED',
+  DEVICE_NOT_SUPPORTED = 'DEVICE_NOT_SUPPORTED',
+  
+  // Unknown error
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR'
+}
+
+/**
+ * PayPal SDK error class
+ */
+export class PayPalSdkError extends Error {
+  /** Error code */
+  code: ErrorCode;
+  
+  /** Debug ID for PayPal support */
+  debugId?: string;
+  
+  /** Additional error details */
+  details?: any;
+  
+  /** Order ID if applicable */
+  orderId?: string;
+  
+  /** Original error if wrapped */
+  originalError?: Error;
+  
+  /** Timestamp when error occurred */
+  timestamp: number;
+  
+  constructor(
+    code: ErrorCode,
+    message: string,
+    options?: {
+      debugId?: string;
+      details?: any;
+      orderId?: string;
+      originalError?: Error;
+    }
+  ) {
+    super(message);
+    this.name = 'PayPalSdkError';
+    this.code = code;
+    this.debugId = options?.debugId;
+    this.details = options?.details;
+    this.orderId = options?.orderId;
+    this.originalError = options?.originalError;
+    this.timestamp = Date.now();
+    
+    // Maintains proper stack trace for where our error was thrown
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PayPalSdkError);
+    }
+  }
+  
+  /**
+   * Convert error to JSON
+   */
+  toJSON() {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      debugId: this.debugId,
+      details: this.details,
+      orderId: this.orderId,
+      timestamp: this.timestamp,
+      stack: this.stack
+    };
+  }
+}
+
+/**
+ * Error handler function type
+ */
+export type ErrorHandler = (error: PayPalSdkError) => void;
+
+/**
+ * Retry configuration
+ */
+export interface RetryConfig {
+  /** Maximum number of retry attempts */
+  maxAttempts?: number;
+  
+  /** Initial delay in milliseconds */
+  initialDelay?: number;
+  
+  /** Maximum delay in milliseconds */
+  maxDelay?: number;
+  
+  /** Backoff multiplier */
+  backoffMultiplier?: number;
+  
+  /** Retry condition function */
+  shouldRetry?: (error: PayPalSdkError, attemptNumber: number) => boolean;
+}
+
+/**
+ * Error recovery strategies
+ */
+export enum ErrorRecoveryStrategy {
+  /** Retry the operation */
+  RETRY = 'RETRY',
+  
+  /** Fall back to alternative payment method */
+  FALLBACK = 'FALLBACK',
+  
+  /** Show error message to user */
+  SHOW_ERROR = 'SHOW_ERROR',
+  
+  /** Reload the page */
+  RELOAD = 'RELOAD',
+  
+  /** Do nothing */
+  IGNORE = 'IGNORE'
+}
+
+/**
+ * Error recovery configuration
+ */
+export interface ErrorRecoveryConfig {
+  /** Strategy to use for recovery */
+  strategy: ErrorRecoveryStrategy;
+  
+  /** Retry configuration if using RETRY strategy */
+  retryConfig?: RetryConfig;
+  
+  /** Fallback payment method if using FALLBACK strategy */
+  fallbackMethod?: string;
+  
+  /** Custom recovery handler */
+  customHandler?: (error: PayPalSdkError) => void | Promise<void>;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,7 @@
+export * from './sdk';
+export * from './payment-methods';
+export * from './orders';
+export * from './callbacks';
+export * from './components';
+export * from './errors';
+export * from './config';

--- a/packages/types/src/orders.ts
+++ b/packages/types/src/orders.ts
@@ -1,0 +1,453 @@
+/**
+ * Order intent
+ */
+export enum OrderIntent {
+  CAPTURE = 'CAPTURE',
+  AUTHORIZE = 'AUTHORIZE'
+}
+
+/**
+ * Order status
+ */
+export enum OrderStatus {
+  CREATED = 'CREATED',
+  SAVED = 'SAVED',
+  APPROVED = 'APPROVED',
+  VOIDED = 'VOIDED',
+  COMPLETED = 'COMPLETED',
+  PAYER_ACTION_REQUIRED = 'PAYER_ACTION_REQUIRED'
+}
+
+/**
+ * Currency codes
+ */
+export type CurrencyCode = 'USD' | 'EUR' | 'GBP' | 'CAD' | 'AUD' | 'JPY' | string;
+
+/**
+ * Money amount
+ */
+export interface Amount {
+  /** Currency code */
+  currencyCode: CurrencyCode;
+  
+  /** Value as string to preserve precision */
+  value: string;
+  
+  /** Breakdown of amount */
+  breakdown?: AmountBreakdown;
+}
+
+/**
+ * Amount breakdown
+ */
+export interface AmountBreakdown {
+  /** Item total */
+  itemTotal?: Money;
+  
+  /** Shipping cost */
+  shipping?: Money;
+  
+  /** Tax amount */
+  taxTotal?: Money;
+  
+  /** Handling fee */
+  handling?: Money;
+  
+  /** Insurance cost */
+  insurance?: Money;
+  
+  /** Shipping discount */
+  shippingDiscount?: Money;
+  
+  /** Discount amount */
+  discount?: Money;
+}
+
+/**
+ * Simple money object
+ */
+export interface Money {
+  /** Currency code */
+  currencyCode: CurrencyCode;
+  
+  /** Value as string */
+  value: string;
+}
+
+/**
+ * Item in a purchase
+ */
+export interface Item {
+  /** Item name */
+  name: string;
+  
+  /** Item description */
+  description?: string;
+  
+  /** SKU */
+  sku?: string;
+  
+  /** Unit amount */
+  unitAmount: Money;
+  
+  /** Quantity */
+  quantity: string;
+  
+  /** Category */
+  category?: 'DIGITAL_GOODS' | 'PHYSICAL_GOODS' | 'DONATION';
+  
+  /** Tax amount */
+  tax?: Money;
+}
+
+/**
+ * Shipping address
+ */
+export interface ShippingAddress {
+  /** Address line 1 */
+  addressLine1?: string;
+  
+  /** Address line 2 */
+  addressLine2?: string;
+  
+  /** Admin area 2 (city) */
+  adminArea2?: string;
+  
+  /** Admin area 1 (state/province) */
+  adminArea1?: string;
+  
+  /** Postal code */
+  postalCode?: string;
+  
+  /** Country code */
+  countryCode: string;
+}
+
+/**
+ * Shipping option
+ */
+export interface ShippingOption {
+  /** Unique ID for this option */
+  id: string;
+  
+  /** Label for the option */
+  label: string;
+  
+  /** Whether this is the selected option */
+  selected: boolean;
+  
+  /** Shipping amount */
+  amount: Money;
+  
+  /** Type of shipping */
+  type?: 'SHIPPING' | 'PICKUP';
+}
+
+/**
+ * Purchase unit
+ */
+export interface PurchaseUnit {
+  /** Reference ID */
+  referenceId?: string;
+  
+  /** Amount for this purchase unit */
+  amount: Amount;
+  
+  /** Items in this purchase unit */
+  items?: Item[];
+  
+  /** Shipping information */
+  shipping?: {
+    name?: {
+      fullName?: string;
+    };
+    address?: ShippingAddress;
+    options?: ShippingOption[];
+  };
+  
+  /** Description */
+  description?: string;
+  
+  /** Custom ID */
+  customId?: string;
+  
+  /** Invoice ID */
+  invoiceId?: string;
+  
+  /** Soft descriptor */
+  softDescriptor?: string;
+}
+
+/**
+ * Payer information
+ */
+export interface Payer {
+  /** Payer ID */
+  payerId?: string;
+  
+  /** Email address */
+  email?: string;
+  
+  /** Name */
+  name?: {
+    givenName?: string;
+    surname?: string;
+  };
+  
+  /** Phone number */
+  phone?: {
+    phoneType?: 'FAX' | 'HOME' | 'MOBILE' | 'OTHER' | 'PAGER';
+    phoneNumber?: {
+      nationalNumber?: string;
+    };
+  };
+  
+  /** Birth date */
+  birthDate?: string;
+  
+  /** Tax info */
+  taxInfo?: {
+    taxId?: string;
+    taxIdType?: string;
+  };
+  
+  /** Address */
+  address?: ShippingAddress;
+}
+
+/**
+ * Payment source
+ */
+export interface PaymentSource {
+  /** PayPal payment */
+  paypal?: {
+    emailAddress?: string;
+    accountId?: string;
+    accountStatus?: string;
+    name?: {
+      givenName?: string;
+      surname?: string;
+    };
+    phoneNumber?: {
+      nationalNumber?: string;
+    };
+    address?: ShippingAddress;
+    attributes?: {
+      vault?: {
+        storeInVault?: 'ON_SUCCESS';
+        description?: string;
+        usagePattern?: 'IMMEDIATE' | 'DEFERRED';
+        usageType?: 'MERCHANT' | 'PLATFORM' | 'FIRST' | 'SUBSEQUENT';
+        customerType?: 'CONSUMER' | 'BUSINESS';
+        permitMultiplePaymentTokens?: boolean;
+      };
+    };
+  };
+  
+  /** Venmo payment */
+  venmo?: {
+    emailAddress?: string;
+    accountId?: string;
+    userName?: string;
+    name?: {
+      givenName?: string;
+      surname?: string;
+    };
+    phoneNumber?: {
+      nationalNumber?: string;
+    };
+    address?: ShippingAddress;
+    attributes?: {
+      vault?: {
+        storeInVault?: 'ON_SUCCESS';
+        description?: string;
+        usagePattern?: 'IMMEDIATE' | 'DEFERRED';
+        usageType?: 'MERCHANT' | 'PLATFORM' | 'FIRST' | 'SUBSEQUENT';
+        customerType?: 'CONSUMER' | 'BUSINESS';
+        permitMultiplePaymentTokens?: boolean;
+      };
+    };
+  };
+  
+  /** Google Pay payment */
+  googlePay?: {
+    name?: string;
+    emailAddress?: string;
+    phoneNumber?: {
+      countryCode?: string;
+      nationalNumber?: string;
+    };
+    card?: {
+      name?: string;
+      lastDigits?: string;
+      type?: 'CREDIT' | 'DEBIT' | 'UNKNOWN';
+      brand?: string;
+      billingAddress?: ShippingAddress;
+    };
+    attributes?: {
+      verification?: {
+        method?: 'SCA_WHEN_REQUIRED' | 'SCA_ALWAYS';
+      };
+    };
+  };
+  
+  /** Apple Pay payment */
+  applePay?: {
+    id?: string;
+    name?: string;
+    emailAddress?: string;
+    phoneNumber?: {
+      countryCode?: string;
+      nationalNumber?: string;
+    };
+    card?: {
+      name?: string;
+      lastDigits?: string;
+      type?: 'CREDIT' | 'DEBIT' | 'UNKNOWN';
+      brand?: string;
+      billingAddress?: ShippingAddress;
+    };
+  };
+  
+  /** Card payment */
+  card?: {
+    id?: string;
+    name?: string;
+    number?: string;
+    lastDigits?: string;
+    expiry?: string;
+    securityCode?: string;
+    type?: 'CREDIT' | 'DEBIT' | 'UNKNOWN';
+    brand?: string;
+    billingAddress?: ShippingAddress;
+    attributes?: {
+      vault?: {
+        storeInVault?: 'ON_SUCCESS';
+      };
+      verification?: {
+        method?: 'SCA_WHEN_REQUIRED' | 'SCA_ALWAYS' | 'AVS_AND_CVV' | 'CVV' | 'AVS';
+      };
+    };
+  };
+}
+
+/**
+ * Create order request
+ */
+export interface CreateOrderRequest {
+  /** Order intent */
+  intent: OrderIntent;
+  
+  /** Purchase units */
+  purchaseUnits: PurchaseUnit[];
+  
+  /** Payment source */
+  paymentSource?: PaymentSource;
+  
+  /** Payer information */
+  payer?: Payer;
+  
+  /** Application context */
+  applicationContext?: ApplicationContext;
+}
+
+/**
+ * Application context
+ */
+export interface ApplicationContext {
+  /** Brand name */
+  brandName?: string;
+  
+  /** Locale */
+  locale?: string;
+  
+  /** Landing page */
+  landingPage?: 'LOGIN' | 'BILLING' | 'NO_PREFERENCE';
+  
+  /** Shipping preference */
+  shippingPreference?: 'GET_FROM_FILE' | 'NO_SHIPPING' | 'SET_PROVIDED_ADDRESS';
+  
+  /** User action */
+  userAction?: 'CONTINUE' | 'PAY_NOW';
+  
+  /** Payment method preference */
+  paymentMethodPreference?: 'IMMEDIATE_PAYMENT_REQUIRED' | 'UNRESTRICTED';
+  
+  /** Return URL */
+  returnUrl?: string;
+  
+  /** Cancel URL */
+  cancelUrl?: string;
+  
+  /** Stored payment source */
+  storedPaymentSource?: {
+    paymentInitiator?: 'CUSTOMER' | 'MERCHANT';
+    paymentType?: 'ONE_TIME' | 'RECURRING' | 'UNSCHEDULED';
+    usage?: 'FIRST' | 'SUBSEQUENT' | 'DERIVED';
+    previousTransactionReference?: string;
+  };
+}
+
+/**
+ * Order response
+ */
+export interface Order {
+  /** Order ID */
+  id: string;
+  
+  /** Order status */
+  status: OrderStatus;
+  
+  /** Order intent */
+  intent: OrderIntent;
+  
+  /** Purchase units */
+  purchaseUnits: PurchaseUnit[];
+  
+  /** Payer information */
+  payer?: Payer;
+  
+  /** Payment source */
+  paymentSource?: PaymentSource;
+  
+  /** Create time */
+  createTime?: string;
+  
+  /** Update time */
+  updateTime?: string;
+  
+  /** Links */
+  links?: Array<{
+    href: string;
+    rel: string;
+    method?: string;
+  }>;
+}
+
+/**
+ * Capture order response
+ */
+export interface CaptureOrderResponse extends Order {
+  /** Purchase units with capture details */
+  purchaseUnits: Array<PurchaseUnit & {
+    payments?: {
+      captures?: Array<{
+        id: string;
+        status: 'COMPLETED' | 'DECLINED' | 'PARTIALLY_REFUNDED' | 'PENDING' | 'REFUNDED' | 'FAILED';
+        amount: Money;
+        finalCapture?: boolean;
+        sellerProtection?: {
+          status: 'ELIGIBLE' | 'PARTIALLY_ELIGIBLE' | 'NOT_ELIGIBLE';
+          disputeCategories?: string[];
+        };
+        sellerReceivableBreakdown?: {
+          grossAmount: Money;
+          paypalFee?: Money;
+          netAmount: Money;
+        };
+        createTime?: string;
+        updateTime?: string;
+      }>;
+    };
+  }>;
+}

--- a/packages/types/src/payment-methods.ts
+++ b/packages/types/src/payment-methods.ts
@@ -1,0 +1,185 @@
+/**
+ * Supported payment methods
+ */
+export enum PaymentMethod {
+  PAYPAL = 'paypal',
+  VENMO = 'venmo',
+  PAYLATER = 'paylater',
+  CREDIT = 'credit',
+  GOOGLE_PAY = 'googlepay',
+  APPLE_PAY = 'applepay',
+  CARD = 'card',
+  IDEAL = 'ideal',
+  SEPA = 'sepa',
+  BANCONTACT = 'bancontact',
+  GIROPAY = 'giropay',
+  SOFORT = 'sofort',
+  EPS = 'eps',
+  MYBANK = 'mybank',
+  P24 = 'p24',
+  BLIK = 'blik'
+}
+
+/**
+ * Presentation modes for payment UI
+ */
+export enum PresentationMode {
+  AUTO = 'auto',
+  POPUP = 'popup',
+  MODAL = 'modal',
+  PAYMENT_HANDLER = 'payment-handler',
+  REDIRECT = 'redirect',
+  INLINE = 'inline'
+}
+
+/**
+ * Google Pay configuration
+ */
+export interface GooglePayConfig {
+  /** API version for Google Pay */
+  apiVersion: number;
+  
+  /** API version minor */
+  apiVersionMinor: number;
+  
+  /** Allowed payment methods for Google Pay */
+  allowedPaymentMethods: GooglePayPaymentMethod[];
+  
+  /** Merchant information */
+  merchantInfo: GooglePayMerchantInfo;
+  
+  /** Country code */
+  countryCode: string;
+  
+  /** Environment (TEST or PRODUCTION) */
+  environment?: 'TEST' | 'PRODUCTION';
+}
+
+/**
+ * Google Pay payment method configuration
+ */
+export interface GooglePayPaymentMethod {
+  /** Type of payment method */
+  type: 'CARD';
+  
+  /** Parameters for the payment method */
+  parameters: {
+    allowedAuthMethods: string[];
+    allowedCardNetworks: string[];
+    billingAddressRequired?: boolean;
+    billingAddressParameters?: {
+      format?: 'MIN' | 'FULL';
+      phoneNumberRequired?: boolean;
+    };
+  };
+  
+  /** Tokenization specification */
+  tokenizationSpecification: {
+    type: 'PAYMENT_GATEWAY';
+    parameters: {
+      gateway: string;
+      gatewayMerchantId: string;
+    };
+  };
+}
+
+/**
+ * Google Pay merchant information
+ */
+export interface GooglePayMerchantInfo {
+  /** Merchant ID */
+  merchantId?: string;
+  
+  /** Merchant name */
+  merchantName: string;
+}
+
+/**
+ * Google Pay transaction info
+ */
+export interface GooglePayTransactionInfo {
+  /** Currency code */
+  currencyCode: string;
+  
+  /** Country code */
+  countryCode: string;
+  
+  /** Total price status */
+  totalPriceStatus: 'FINAL' | 'ESTIMATED';
+  
+  /** Total price */
+  totalPrice: string;
+  
+  /** Total price label */
+  totalPriceLabel?: string;
+  
+  /** Display items */
+  displayItems?: Array<{
+    label: string;
+    type: 'LINE_ITEM' | 'SUBTOTAL' | 'TAX' | 'DISCOUNT';
+    price: string;
+  }>;
+  
+  /** Checkout option */
+  checkoutOption?: 'DEFAULT' | 'COMPLETE_IMMEDIATE_PURCHASE';
+}
+
+/**
+ * Apple Pay configuration
+ */
+export interface ApplePayConfig {
+  /** Country code */
+  countryCode: string;
+  
+  /** Currency code */
+  currencyCode: string;
+  
+  /** Merchant capabilities */
+  merchantCapabilities: string[];
+  
+  /** Supported networks */
+  supportedNetworks: string[];
+  
+  /** Apple Pay version */
+  version: number;
+}
+
+/**
+ * Card details for saved payment methods
+ */
+export interface CardDetails {
+  /** Last 4 digits of card number */
+  lastDigits: string;
+  
+  /** Card brand (VISA, MASTERCARD, etc.) */
+  brand: string;
+  
+  /** Card type (CREDIT, DEBIT) */
+  type?: 'CREDIT' | 'DEBIT';
+  
+  /** Expiry month (MM) */
+  expiryMonth?: string;
+  
+  /** Expiry year (YYYY) */
+  expiryYear?: string;
+}
+
+/**
+ * Saved payment method
+ */
+export interface SavedPaymentMethod {
+  /** Unique identifier for the payment method */
+  id: string;
+  
+  /** Type of payment method */
+  type: PaymentMethod;
+  
+  /** Card details if applicable */
+  cardDetails?: CardDetails;
+  
+  /** Email associated with PayPal/Venmo */
+  email?: string;
+  
+  /** Whether this is the default payment method */
+  isDefault?: boolean;
+}

--- a/packages/types/src/sdk.ts
+++ b/packages/types/src/sdk.ts
@@ -1,0 +1,151 @@
+import type { PaymentSessionOptions, PaymentSession } from './callbacks';
+import type { Component, PageType } from './components';
+import type { GooglePayConfig } from './payment-methods';
+
+/**
+ * Options for creating a PayPal SDK instance
+ */
+export interface CreateInstanceOptions {
+  /** Browser-safe client token obtained from the server */
+  clientToken: string;
+  
+  /** Components to load with the SDK */
+  components?: Component[];
+  
+  /** Type of page where SDK is being loaded */
+  pageType?: PageType;
+  
+  /** Locale for the SDK (e.g., 'en_US') */
+  locale?: string;
+  
+  /** Partner attribution ID */
+  partnerAttributionId?: string;
+  
+  /** Client metadata ID for tracking */
+  clientMetadataId?: string;
+}
+
+/**
+ * Options for finding eligible payment methods
+ */
+export interface FindEligibleMethodsOptions {
+  /** Currency code (e.g., 'USD') */
+  currencyCode?: string;
+  
+  /** Country code (e.g., 'US') */
+  countryCode?: string;
+  
+  /** Total amount for the transaction */
+  amount?: string | number;
+}
+
+/**
+ * Payment method details returned by eligibility check
+ */
+export interface PaymentMethodDetails {
+  /** Product code for pay later options */
+  productCode?: string;
+  
+  /** Country code where method is available */
+  countryCode?: string;
+  
+  /** Display name of the payment method */
+  displayName?: string;
+  
+  /** Whether the method is enabled */
+  enabled: boolean;
+}
+
+/**
+ * Eligible payment methods interface
+ */
+export interface EligiblePaymentMethods {
+  /** Check if a payment method is eligible */
+  isEligible(paymentMethod: string): boolean;
+  
+  /** Get details for a specific payment method */
+  getDetails(paymentMethod: string): PaymentMethodDetails | null;
+  
+  /** Get all eligible payment methods */
+  getAllEligible(): string[];
+}
+
+/**
+ * Main PayPal SDK instance
+ */
+export interface SdkInstance {
+  /** Create a one-time PayPal payment session */
+  createPayPalOneTimePaymentSession(options: PaymentSessionOptions): PaymentSession;
+  
+  /** Create a one-time Venmo payment session */
+  createVenmoOneTimePaymentSession(options: PaymentSessionOptions): PaymentSession;
+  
+  /** Create a one-time Pay Later payment session */
+  createPayLaterOneTimePaymentSession(options: PaymentSessionOptions): PaymentSession;
+  
+  /** Create a one-time PayPal Credit payment session */
+  createPayPalCreditOneTimePaymentSession(options: PaymentSessionOptions): PaymentSession;
+  
+  /** Create a one-time Google Pay payment session */
+  createGooglePayOneTimePaymentSession(): GooglePaySession;
+  
+  /** Create a one-time Apple Pay payment session */
+  createApplePayOneTimePaymentSession(options: PaymentSessionOptions): ApplePaySession;
+  
+  /** Create a saved payment method session */
+  createSavedPaymentMethodSession(options: PaymentSessionOptions): PaymentSession;
+  
+  /** Find eligible payment methods */
+  findEligibleMethods(options: FindEligibleMethodsOptions): Promise<EligiblePaymentMethods>;
+  
+  /** Destroy the SDK instance and clean up */
+  destroy(): void;
+}
+
+/**
+ * Google Pay specific session interface
+ */
+export interface GooglePaySession {
+  /** Get Google Pay configuration */
+  getGooglePayConfig(): Promise<GooglePayConfig>;
+  
+  /** Confirm an order with Google Pay */
+  confirmOrder(options: {
+    orderId: string;
+    paymentMethodData: any;
+  }): Promise<{ status: string }>;
+}
+
+/**
+ * Apple Pay specific session interface
+ */
+export interface ApplePaySession extends PaymentSession {
+  /** Get Apple Pay configuration */
+  getApplePayConfig(): Promise<any>;
+  
+  /** Validate merchant session */
+  validateMerchant(validationURL: string): Promise<any>;
+}
+
+/**
+ * Global PayPal object attached to window
+ */
+export interface PayPalGlobal {
+  /** Create a new SDK instance */
+  createInstance(options: CreateInstanceOptions): Promise<SdkInstance>;
+  
+  /** SDK version */
+  version?: string;
+  
+  /** Check if SDK is loaded */
+  isLoaded?: boolean;
+}
+
+/**
+ * Extend Window interface with PayPal
+ */
+declare global {
+  interface Window {
+    paypal: PayPalGlobal;
+  }
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  splitting: false,
+});

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@paypal-v6/vue",
+  "version": "0.1.0",
+  "description": "Vue composables and components for PayPal v6 Web SDK",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@paypal-v6/core": "workspace:*",
+    "@paypal-v6/types": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "vitest": "^2.1.8",
+    "typescript": "^5.8.3",
+    "vue": "^3.5.13"
+  },
+  "peerDependencies": {
+    "vue": ">=3.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/vue/tsup.config.ts
+++ b/packages/vue/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  splitting: false,
+  external: ['vue', '@paypal-v6/core', '@paypal-v6/types'],
+});


### PR DESCRIPTION
- Create monorepo structure with npm workspaces
- Add @paypal-v6/types package with comprehensive TypeScript definitions
- Add @paypal-v6/core package with SDK loader, session management, and utilities
- Add @paypal-v6/react package with hooks and components
- Add @paypal-v6/vue package structure (implementation pending)
- Include README_SDK.md with complete documentation

This provides a modern, type-safe wrapper around PayPal's v6 Web SDK for easier integration in JavaScript applications.