### PR TITLE
Updated V6 Card Fields examples to leverage eligibility API

### DIFF
--- a/client/prebuiltPages/react/src/pages/CardFieldsSavePaymentSettings.tsx
+++ b/client/prebuiltPages/react/src/pages/CardFieldsSavePaymentSettings.tsx
@@ -13,16 +13,18 @@ const SavePaymentSettings = () => {
   const [modalState, setModalState] = useState<ModalType>(null);
   const { loadingStatus } = usePayPal();
 
-  const { error: eligibilityError, eligiblePaymentMethods } = useEligibleMethods({
-    payload: {
-      currencyCode: "USD",
-      paymentFlow: "VAULT_WITHOUT_PAYMENT",
-    },
-  });
+  const { error: eligibilityError, eligiblePaymentMethods } =
+    useEligibleMethods({
+      payload: {
+        currencyCode: "USD",
+        paymentFlow: "VAULT_WITHOUT_PAYMENT",
+      },
+    });
 
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
   const isEligibilityResolved = !!eligiblePaymentMethods || !!eligibilityError;
-  const isCardFieldsEligible = eligiblePaymentMethods?.isEligible("advanced_cards");
+  const isCardFieldsEligible =
+    eligiblePaymentMethods?.isEligible("advanced_cards");
 
   const getModalContent = useCallback(
     (state: ModalType): ModalContent | null => {
@@ -169,11 +171,11 @@ const SavePaymentSettings = () => {
             Add a Payment Method
           </h3>
 
-          {(isLoading || !isEligibilityResolved) ? (
+          {isLoading || !isEligibilityResolved ? (
             <div style={{ padding: "1rem", textAlign: "center" }}>
               Loading card fields...
             </div>
-          ) : (eligibilityError || !isCardFieldsEligible) ? (
+          ) : eligibilityError || !isCardFieldsEligible ? (
             <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
               Failed to load card fields. Please refresh the page.
             </div>

--- a/client/prebuiltPages/react/src/pages/CardFieldsSavePaymentSettings.tsx
+++ b/client/prebuiltPages/react/src/pages/CardFieldsSavePaymentSettings.tsx
@@ -13,7 +13,7 @@ const SavePaymentSettings = () => {
   const [modalState, setModalState] = useState<ModalType>(null);
   const { loadingStatus } = usePayPal();
 
-  const { error: eligibilityError } = useEligibleMethods({
+  const { error: eligibilityError, eligiblePaymentMethods } = useEligibleMethods({
     payload: {
       currencyCode: "USD",
       paymentFlow: "VAULT_WITHOUT_PAYMENT",
@@ -21,6 +21,8 @@ const SavePaymentSettings = () => {
   });
 
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
+  const isEligibilityResolved = !!eligiblePaymentMethods || !!eligibilityError;
+  const isCardFieldsEligible = eligiblePaymentMethods?.isEligible("advanced_cards");
 
   const getModalContent = useCallback(
     (state: ModalType): ModalContent | null => {
@@ -167,11 +169,11 @@ const SavePaymentSettings = () => {
             Add a Payment Method
           </h3>
 
-          {isLoading ? (
+          {(isLoading || !isEligibilityResolved) ? (
             <div style={{ padding: "1rem", textAlign: "center" }}>
               Loading card fields...
             </div>
-          ) : eligibilityError ? (
+          ) : (eligibilityError || !isCardFieldsEligible) ? (
             <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
               Failed to load card fields. Please refresh the page.
             </div>

--- a/client/prebuiltPages/react/src/pages/CardFieldsSavePaymentSettings.tsx
+++ b/client/prebuiltPages/react/src/pages/CardFieldsSavePaymentSettings.tsx
@@ -13,17 +13,20 @@ const SavePaymentSettings = () => {
   const [modalState, setModalState] = useState<ModalType>(null);
   const { loadingStatus } = usePayPal();
 
-  const { error: eligibilityError, eligiblePaymentMethods } =
-    useEligibleMethods({
-      payload: {
-        currencyCode: "USD",
-        paymentFlow: "VAULT_WITHOUT_PAYMENT",
-      },
-    });
+  const {
+    error: eligibilityError,
+    eligiblePaymentMethods,
+    isLoading: isEligibilityLoading,
+  } = useEligibleMethods({
+    payload: {
+      currencyCode: "USD",
+      paymentFlow: "VAULT_WITHOUT_PAYMENT",
+    },
+  });
 
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
-  const isEligibilityResolved = !!eligiblePaymentMethods || !!eligibilityError;
   const isCardFieldsEligible =
+    !isEligibilityLoading &&
     eligiblePaymentMethods?.isEligible("advanced_cards");
 
   const getModalContent = useCallback(
@@ -171,19 +174,21 @@ const SavePaymentSettings = () => {
             Add a Payment Method
           </h3>
 
-          {isLoading || !isEligibilityResolved ? (
+          {isLoading ? (
             <div style={{ padding: "1rem", textAlign: "center" }}>
               Loading card fields...
             </div>
-          ) : eligibilityError || !isCardFieldsEligible ? (
+          ) : eligibilityError ? (
             <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
               Failed to load card fields. Please refresh the page.
             </div>
           ) : (
             <>
-              <PayPalCardFieldsProvider>
-                <PayPalCardFieldsSavePayment setModalState={setModalState} />
-              </PayPalCardFieldsProvider>
+              {isCardFieldsEligible && (
+                <PayPalCardFieldsProvider>
+                  <PayPalCardFieldsSavePayment setModalState={setModalState} />
+                </PayPalCardFieldsProvider>
+              )}
             </>
           )}
         </div>

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/CardFieldsOneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/CardFieldsOneTimePaymentCheckout.tsx
@@ -21,12 +21,15 @@ const CardFieldsOneTimePaymentCheckout = () => {
   const navigate = useNavigate();
 
   // Fetch eligibility for one-time payment flow
-  const { error: eligibilityError } = useEligibleMethods({
+  const { error: eligibilityError, eligiblePaymentMethods } = useEligibleMethods({
     payload: {
       currencyCode: "USD",
       paymentFlow: "ONE_TIME_PAYMENT",
     },
   });
+
+  const isEligibilityResolved = !!eligiblePaymentMethods || !!eligibilityError;
+  const isCardFieldsEligible = eligiblePaymentMethods?.isEligible("advanced_cards");
 
   const getModalContent = useCallback(
     (state: ModalType): ModalContent | null => {
@@ -58,11 +61,11 @@ const CardFieldsOneTimePaymentCheckout = () => {
     }
   };
 
-  const payPalCardFieldsOneTimePayment = isLoading ? (
+  const payPalCardFieldsOneTimePayment = (isLoading || !isEligibilityResolved) ? (
     <div style={{ padding: "1rem", textAlign: "center" }}>
       Loading card fields...
     </div>
-  ) : eligibilityError ? (
+  ) : (eligibilityError || !isCardFieldsEligible) ? (
     <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
       Failed to load card fields. Please refresh the page.
     </div>

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/CardFieldsOneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/CardFieldsOneTimePaymentCheckout.tsx
@@ -21,15 +21,17 @@ const CardFieldsOneTimePaymentCheckout = () => {
   const navigate = useNavigate();
 
   // Fetch eligibility for one-time payment flow
-  const { error: eligibilityError, eligiblePaymentMethods } = useEligibleMethods({
-    payload: {
-      currencyCode: "USD",
-      paymentFlow: "ONE_TIME_PAYMENT",
-    },
-  });
+  const { error: eligibilityError, eligiblePaymentMethods } =
+    useEligibleMethods({
+      payload: {
+        currencyCode: "USD",
+        paymentFlow: "ONE_TIME_PAYMENT",
+      },
+    });
 
   const isEligibilityResolved = !!eligiblePaymentMethods || !!eligibilityError;
-  const isCardFieldsEligible = eligiblePaymentMethods?.isEligible("advanced_cards");
+  const isCardFieldsEligible =
+    eligiblePaymentMethods?.isEligible("advanced_cards");
 
   const getModalContent = useCallback(
     (state: ModalType): ModalContent | null => {
@@ -61,21 +63,22 @@ const CardFieldsOneTimePaymentCheckout = () => {
     }
   };
 
-  const payPalCardFieldsOneTimePayment = (isLoading || !isEligibilityResolved) ? (
-    <div style={{ padding: "1rem", textAlign: "center" }}>
-      Loading card fields...
-    </div>
-  ) : (eligibilityError || !isCardFieldsEligible) ? (
-    <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
-      Failed to load card fields. Please refresh the page.
-    </div>
-  ) : (
-    <>
-      <PayPalCardFieldsProvider>
-        <PayPalCardFieldsOneTimePayment setModalState={setModalState} />
-      </PayPalCardFieldsProvider>
-    </>
-  );
+  const payPalCardFieldsOneTimePayment =
+    isLoading || !isEligibilityResolved ? (
+      <div style={{ padding: "1rem", textAlign: "center" }}>
+        Loading card fields...
+      </div>
+    ) : eligibilityError || !isCardFieldsEligible ? (
+      <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
+        Failed to load card fields. Please refresh the page.
+      </div>
+    ) : (
+      <>
+        <PayPalCardFieldsProvider>
+          <PayPalCardFieldsOneTimePayment setModalState={setModalState} />
+        </PayPalCardFieldsProvider>
+      </>
+    );
 
   return (
     <BaseCardFieldsCheckout

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/CardFieldsOneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/CardFieldsOneTimePaymentCheckout.tsx
@@ -21,16 +21,19 @@ const CardFieldsOneTimePaymentCheckout = () => {
   const navigate = useNavigate();
 
   // Fetch eligibility for one-time payment flow
-  const { error: eligibilityError, eligiblePaymentMethods } =
-    useEligibleMethods({
-      payload: {
-        currencyCode: "USD",
-        paymentFlow: "ONE_TIME_PAYMENT",
-      },
-    });
+  const {
+    error: eligibilityError,
+    eligiblePaymentMethods,
+    isLoading: isEligibilityLoading,
+  } = useEligibleMethods({
+    payload: {
+      currencyCode: "USD",
+      paymentFlow: "ONE_TIME_PAYMENT",
+    },
+  });
 
-  const isEligibilityResolved = !!eligiblePaymentMethods || !!eligibilityError;
   const isCardFieldsEligible =
+    !isEligibilityLoading &&
     eligiblePaymentMethods?.isEligible("advanced_cards");
 
   const getModalContent = useCallback(
@@ -63,22 +66,23 @@ const CardFieldsOneTimePaymentCheckout = () => {
     }
   };
 
-  const payPalCardFieldsOneTimePayment =
-    isLoading || !isEligibilityResolved ? (
-      <div style={{ padding: "1rem", textAlign: "center" }}>
-        Loading card fields...
-      </div>
-    ) : eligibilityError || !isCardFieldsEligible ? (
-      <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
-        Failed to load card fields. Please refresh the page.
-      </div>
-    ) : (
-      <>
+  const payPalCardFieldsOneTimePayment = isLoading ? (
+    <div style={{ padding: "1rem", textAlign: "center" }}>
+      Loading card fields...
+    </div>
+  ) : eligibilityError ? (
+    <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
+      Failed to load card fields. Please refresh the page.
+    </div>
+  ) : (
+    <>
+      {isCardFieldsEligible && (
         <PayPalCardFieldsProvider>
           <PayPalCardFieldsOneTimePayment setModalState={setModalState} />
         </PayPalCardFieldsProvider>
-      </>
-    );
+      )}
+    </>
+  );
 
   return (
     <BaseCardFieldsCheckout


### PR DESCRIPTION
Updated the following V6 Card Fields examples to validate eligibility via the `useEligibleMethods` hook:

- Card Fields One time payment
- Card Fields Save payment

With the updated logic, Card Fields will only render after:

- No loading errors were returned
- Eligibility API returned a response and Card Fields is eligible

Otherwise an error message will be rendered.