### PR TITLE
fix: upgrade to latest react-paypal-js and fix types

### DIFF
--- a/client/prebuiltPages/react/package-lock.json
+++ b/client/prebuiltPages/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "paypal-sdk-v6-checkout-demos",
       "version": "1.0.0",
       "dependencies": {
-        "@paypal/react-paypal-js": "^9.0.1",
+        "@paypal/react-paypal-js": "^9.0.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-error-boundary": "6.1.0",
@@ -1072,21 +1072,21 @@
       }
     },
     "node_modules/@paypal/paypal-js": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-9.4.0.tgz",
-      "integrity": "sha512-iPJIkEgzuUt9AW9d41xcltLYdcJvQ0qf+wWWuJ+wnJYnx4H6Yf1Pm98eBRnTNej4XHMSEDDb33ERsB4v/siORQ==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-9.4.1.tgz",
+      "integrity": "sha512-NOrfmY8k/45cBEhB6LStle1EPYiq0XhoSGbh9i4mEBVArPBtHuQ5mHFvvruDOmvVM1mahjJqQKParUW7ZXh8iQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "promise-polyfill": "^8.3.0"
       }
     },
     "node_modules/@paypal/react-paypal-js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-9.0.1.tgz",
-      "integrity": "sha512-cqX0l0wSOlWlovH0dnbVksZNfkoVxoQ5qYSoOQrqiXyibgrNCNT+loYqQ26F3rdCz+qPEQwf4+euKxgw8M1bNQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-9.0.2.tgz",
+      "integrity": "sha512-IGJLsr5O/0wadOx8c4G+3NzEeeI2nBwmkTUq/3LHPx2T77IV8ZldvjVVZExhL6ibasQrgA+rwhd6ijOvnmTwkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@paypal/paypal-js": "^9.4.0",
+        "@paypal/paypal-js": "^9.4.1",
         "@paypal/sdk-constants": "^1.0.122",
         "server-only": "^0.0.1"
       },

--- a/client/prebuiltPages/react/package.json
+++ b/client/prebuiltPages/react/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --build --noEmit"
   },
   "dependencies": {
-    "@paypal/react-paypal-js": "^9.0.1",
+    "@paypal/react-paypal-js": "^9.0.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-error-boundary": "6.1.0",

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
@@ -4,15 +4,15 @@ import {
   usePayPal,
   useEligibleMethods,
   INSTANCE_LOADING_STATE,
-  type OnApproveDataOneTimePayments,
-  type OnErrorData,
-  type OnCompleteData,
-  type OnCancelDataOneTimePayments,
   PayPalOneTimePaymentButton,
   VenmoOneTimePaymentButton,
   PayLaterOneTimePaymentButton,
   PayPalGuestPaymentButton,
   // PayPalCreditOneTimePaymentButton,
+  type OnApproveDataOneTimePayments,
+  type OnErrorData,
+  type OnCompleteData,
+  type OnCancelDataOneTimePayments,
 } from "@paypal/react-paypal-js/sdk-v6";
 import BaseCheckout from "../pages/BaseCheckout";
 import type { ModalType, ModalContent, ProductItem } from "../types";

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/SubscriptionCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/SubscriptionCheckout.tsx
@@ -4,11 +4,11 @@ import {
   usePayPal,
   useEligibleMethods,
   INSTANCE_LOADING_STATE,
+  PayPalSubscriptionButton,
   type OnCompleteData,
   type OnCancelDataOneTimePayments,
   type OnErrorData,
-  PayPalSubscriptionButton,
-  OnApproveDataSubscriptionsPayments,
+  type OnApproveDataSubscriptions,
 } from "@paypal/react-paypal-js/sdk-v6";
 import BaseCheckout from "../pages/BaseCheckout";
 import type { ModalType, ModalContent } from "../types";
@@ -35,7 +35,7 @@ const Checkout = () => {
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleSubscriptionCallbacks = {
-    onApprove: async (data: OnApproveDataSubscriptionsPayments) => {
+    onApprove: async (data: OnApproveDataSubscriptions) => {
       console.log("Subscription approved:", data);
       console.log("Payer ID:", data.payerId);
       setModalState("success");

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/VaultWithPurchaseCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/VaultWithPurchaseCheckout.tsx
@@ -4,12 +4,12 @@ import {
   usePayPal,
   useEligibleMethods,
   INSTANCE_LOADING_STATE,
+  PayPalOneTimePaymentButton,
+  PayLaterOneTimePaymentButton,
   type OnApproveDataOneTimePayments,
   type OnErrorData,
   type OnCompleteData,
   type OnCancelDataOneTimePayments,
-  PayPalOneTimePaymentButton,
-  PayLaterOneTimePaymentButton,
 } from "@paypal/react-paypal-js/sdk-v6";
 import BaseCheckout from "../pages/BaseCheckout";
 import type { ModalType, ModalContent, ProductItem } from "../types";


### PR DESCRIPTION
The fly.io deployment failed related to this type rename in paypal-js with `OnApproveDataSubscriptions`. This PR should fix the issue.