### PR TITLE
Fix: React - PayLater and Credit rendering eligibility waterfall

### DIFF
--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
@@ -134,21 +134,20 @@ const OneTimePaymentCheckout = () => {
         {...handlePaymentCallbacks}
       />
 
-      {isPayLaterEligible ? (
+      {isPayLaterEligible && (
         <PayLaterOneTimePaymentButton
           createOrder={handleCreateOrder}
           presentationMode="auto"
           {...handlePaymentCallbacks}
         />
-      ) : (
-        isCreditEligible && (
+      )} 
+        {isCreditEligible && (
           <PayPalCreditOneTimePaymentButton
             createOrder={handleCreateOrder}
             presentationMode="auto"
             {...handlePaymentCallbacks}
           />
-        )
-      )}
+        )}
 
       <PayPalGuestPaymentButton
         createOrder={handleCreateOrder}

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
@@ -8,7 +8,7 @@ import {
   VenmoOneTimePaymentButton,
   PayLaterOneTimePaymentButton,
   PayPalGuestPaymentButton,
-  // PayPalCreditOneTimePaymentButton,
+  PayPalCreditOneTimePaymentButton,
   type OnApproveDataOneTimePayments,
   type OnErrorData,
   type OnCompleteData,
@@ -29,12 +29,13 @@ const OneTimePaymentCheckout = () => {
   const navigate = useNavigate();
 
   // Fetch eligibility for one-time payment flow
-  const { error: eligibilityError } = useEligibleMethods({
-    payload: {
-      currencyCode: "USD",
-      paymentFlow: "ONE_TIME_PAYMENT",
-    },
-  });
+  const { error: eligibilityError, eligiblePaymentMethods } =
+    useEligibleMethods({
+      payload: {
+        currencyCode: "USD",
+        paymentFlow: "ONE_TIME_PAYMENT",
+      },
+    });
 
   const handleCreateOrder = async () => {
     const savedCart = sessionStorage.getItem("cart");
@@ -101,6 +102,8 @@ const OneTimePaymentCheckout = () => {
   );
 
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
+  const isPayLaterEligible = eligiblePaymentMethods?.isEligible("paylater");
+  const isCreditEligible = eligiblePaymentMethods?.isEligible("credit");
 
   const handleModalClose = () => {
     setModalState(null);
@@ -131,21 +134,19 @@ const OneTimePaymentCheckout = () => {
         {...handlePaymentCallbacks}
       />
 
-      <PayLaterOneTimePaymentButton
-        createOrder={handleCreateOrder}
-        presentationMode="auto"
-        {...handlePaymentCallbacks}
-      />
-
-      {/*
-        This is an example of the PayPalCreditOneTimePaymentButton.
-        In this example we leverage the PayLaterOneTimePaymentButton instead of Credit.
-      */}
-      {/* <PayPalCreditOneTimePaymentButton
-        createOrder={handleCreateOrder}
-        presentationMode="auto"
-        {...handlePaymentCallbacks}
-      /> */}
+      {isPayLaterEligible ? (
+        <PayLaterOneTimePaymentButton
+          createOrder={handleCreateOrder}
+          presentationMode="auto"
+          {...handlePaymentCallbacks}
+        />
+      ) : isCreditEligible && (
+        <PayPalCreditOneTimePaymentButton
+          createOrder={handleCreateOrder}
+          presentationMode="auto"
+          {...handlePaymentCallbacks}
+        />
+      )}
 
       <PayPalGuestPaymentButton
         createOrder={handleCreateOrder}

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
@@ -140,14 +140,14 @@ const OneTimePaymentCheckout = () => {
           presentationMode="auto"
           {...handlePaymentCallbacks}
         />
-      )} 
-        {isCreditEligible && (
-          <PayPalCreditOneTimePaymentButton
-            createOrder={handleCreateOrder}
-            presentationMode="auto"
-            {...handlePaymentCallbacks}
-          />
-        )}
+      )}
+      {isCreditEligible && (
+        <PayPalCreditOneTimePaymentButton
+          createOrder={handleCreateOrder}
+          presentationMode="auto"
+          {...handlePaymentCallbacks}
+        />
+      )}
 
       <PayPalGuestPaymentButton
         createOrder={handleCreateOrder}

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
@@ -140,12 +140,14 @@ const OneTimePaymentCheckout = () => {
           presentationMode="auto"
           {...handlePaymentCallbacks}
         />
-      ) : isCreditEligible && (
-        <PayPalCreditOneTimePaymentButton
-          createOrder={handleCreateOrder}
-          presentationMode="auto"
-          {...handlePaymentCallbacks}
-        />
+      ) : (
+        isCreditEligible && (
+          <PayPalCreditOneTimePaymentButton
+            createOrder={handleCreateOrder}
+            presentationMode="auto"
+            {...handlePaymentCallbacks}
+          />
+        )
       )}
 
       <PayPalGuestPaymentButton

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/SubscriptionCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/SubscriptionCheckout.tsx
@@ -8,7 +8,7 @@ import {
   type OnCompleteData,
   type OnCancelDataOneTimePayments,
   type OnErrorData,
-  type OnApproveDataSubscriptions,
+  type OnApproveDataSubscriptionsPayments,
 } from "@paypal/react-paypal-js/sdk-v6";
 import BaseCheckout from "../pages/BaseCheckout";
 import type { ModalType, ModalContent } from "../types";
@@ -35,7 +35,7 @@ const Checkout = () => {
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleSubscriptionCallbacks = {
-    onApprove: async (data: OnApproveDataSubscriptions) => {
+    onApprove: async (data: OnApproveDataSubscriptionsPayments) => {
       console.log("Subscription approved:", data);
       console.log("Payer ID:", data.payerId);
       setModalState("success");

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/SubscriptionCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/SubscriptionCheckout.tsx
@@ -8,7 +8,7 @@ import {
   type OnCompleteData,
   type OnCancelDataOneTimePayments,
   type OnErrorData,
-  type OnApproveDataSubscriptionsPayments,
+  type OnApproveDataSubscriptions,
 } from "@paypal/react-paypal-js/sdk-v6";
 import BaseCheckout from "../pages/BaseCheckout";
 import type { ModalType, ModalContent } from "../types";
@@ -35,7 +35,7 @@ const Checkout = () => {
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
 
   const handleSubscriptionCallbacks = {
-    onApprove: async (data: OnApproveDataSubscriptionsPayments) => {
+    onApprove: async (data: OnApproveDataSubscriptions) => {
       console.log("Subscription approved:", data);
       console.log("Payer ID:", data.payerId);
       setModalState("success");


### PR DESCRIPTION
This fix is meant to update the one-time payment checkout to demonstrate the eligibility logic for rendering PayLater and Credit.