### PR TITLE
feat: use COOP header for html pages

### DIFF
--- a/server/node/src/middleware/crossOriginOpenerPolicyMiddleware.ts
+++ b/server/node/src/middleware/crossOriginOpenerPolicyMiddleware.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 
-export default async function errorMiddleware(
+export default async function crossOriginOpenerPolicyMiddleware(
   request: Request,
   response: Response,
   next: NextFunction,

--- a/server/node/src/middleware/crossOriginOpenerPolicyMiddleware.ts
+++ b/server/node/src/middleware/crossOriginOpenerPolicyMiddleware.ts
@@ -1,0 +1,16 @@
+import type { Request, Response, NextFunction } from "express";
+
+export default async function errorMiddleware(
+  request: Request,
+  response: Response,
+  next: NextFunction,
+) {
+  if (
+    request.accepts("html") &&
+    request.method === "GET" &&
+    request.url.endsWith(".html")
+  ) {
+    response.header("Cross-Origin-Opener-Policy", "same-origin-allow-popups");
+  }
+  next();
+}

--- a/server/node/src/server.ts
+++ b/server/node/src/server.ts
@@ -4,6 +4,7 @@ import cors from "cors";
 
 import routes from "./routes/index";
 import errorMiddleware from "./middleware/errorMiddleware";
+import crossOriginOpenerPolicyMiddleware from "./middleware/crossOriginOpenerPolicyMiddleware";
 
 const CLIENT_STATIC_DIRECTORY =
   process.env.CLIENT_STATIC_DIRECTORY ||
@@ -12,6 +13,7 @@ const CLIENT_STATIC_DIRECTORY =
 
 const app = express();
 
+app.use(crossOriginOpenerPolicyMiddleware);
 app.use(cors());
 app.use(express.json());
 app.use(routes);


### PR DESCRIPTION
This PR adds the response header `Cross-Origin-Opener-Policy: same-origin-allow-popups` to all the static html pages to follow popup best practices:
<img width="1989" height="891" alt="Screenshot 2026-03-23 at 11 53 50 AM" src="https://github.com/user-attachments/assets/58ebf884-777c-4c4c-b29d-73f3008d7010" />

