### PR TITLE
fix: guard eligibility-dependent buttons with isEligibilityLoading to…

### DIFF
--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/OneTimePaymentCheckout.tsx
@@ -29,13 +29,16 @@ const OneTimePaymentCheckout = () => {
   const navigate = useNavigate();
 
   // Fetch eligibility for one-time payment flow
-  const { error: eligibilityError, eligiblePaymentMethods } =
-    useEligibleMethods({
-      payload: {
-        currencyCode: "USD",
-        paymentFlow: "ONE_TIME_PAYMENT",
-      },
-    });
+  const {
+    error: eligibilityError,
+    eligiblePaymentMethods,
+    isLoading: isEligibilityLoading,
+  } = useEligibleMethods({
+    payload: {
+      currencyCode: "USD",
+      paymentFlow: "ONE_TIME_PAYMENT",
+    },
+  });
 
   const handleCreateOrder = async () => {
     const savedCart = sessionStorage.getItem("cart");
@@ -102,8 +105,10 @@ const OneTimePaymentCheckout = () => {
   );
 
   const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
-  const isPayLaterEligible = eligiblePaymentMethods?.isEligible("paylater");
-  const isCreditEligible = eligiblePaymentMethods?.isEligible("credit");
+  const isPayLaterEligible =
+    !isEligibilityLoading && eligiblePaymentMethods?.isEligible("paylater");
+  const isCreditEligible =
+    !isEligibilityLoading && eligiblePaymentMethods?.isEligible("credit");
 
   const handleModalClose = () => {
     setModalState(null);


### PR DESCRIPTION
Refer to this PR:
https://github.com/paypal/paypal-js/pull/880

This fix is to address problems in react demo. When browser already had cached eligibility data, it would display the cached data rather than null. So we propose a fix in `isLoading` and utilize this variable to control how credit buttons and paylater buttons behave:
display null when there's a payload change, waiting for the new request to be resolved.