### PR TITLE
chore: avoid creating an order when async validation fails

### DIFF
--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/merchantAsyncValidation/README.md
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/merchantAsyncValidation/README.md
@@ -66,11 +66,10 @@ The key pattern demonstrated here is:
 
 ```javascript
 async function validateAndCreateOrder() {
-  // Run validation and order creation concurrently
-  const [validationResult, createOrderResult] = await Promise.all([
-    runAsyncValidation(), // Your custom validation logic
-    createOrder(), // PayPal order creation
-  ]);
+  // Your custom validation logic that will throw an error if validation fails
+  await runAsyncValidation();
+  // PayPal order creation
+  const createOrderResult = await createOrder();
 
   return createOrderResult;
 }

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/merchantAsyncValidation/app.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/merchantAsyncValidation/app.js
@@ -54,12 +54,8 @@ async function configurePayPalButton(sdkInstance) {
 
   // Async promise to be passed into .start()
   async function validateAndCreateOrder() {
-    // Run validation and order creation concurrently for better performance
-    // If order creation depends on validation results, switch to sequential execution
-    const [validationResult, createOrderResult] = await Promise.all([
-      runAsyncValidation(),
-      createOrder(),
-    ]);
+    await runAsyncValidation();
+    const createOrderResult = await createOrder();
 
     return createOrderResult;
   }


### PR DESCRIPTION
This PR updates the advanced async validation example to avoid creating a paypal order id when validation fails.