### PR TITLE
chore: remove note about clientToken for ApplePay security

### DIFF
--- a/client/components/applepayPayments/html/README.md
+++ b/client/components/applepayPayments/html/README.md
@@ -158,7 +158,6 @@ Since Apple Pay requires HTTPS to function, you'll need to create a secure tunne
 - **HTTPS Required**: Apple Pay only works over HTTPS
 - **Domain Verification**: Ensure your domain is properly registered in your vite server config and for Apple Pay in your PayPal developer account
 - **Domain Association File**: Keep your Apple Pay domain association file up to date
-- **Client Token Security**: Use browser-safe client tokens for frontend integration
 
 ## 🐛 Troubleshooting
 

--- a/client/components/applepayPayments/html/src/app.js
+++ b/client/components/applepayPayments/html/src/app.js
@@ -38,11 +38,11 @@ async function setupApplePayButton(sdkInstance, applePayPaymentMethodDetails) {
     const paypalSdkApplePayPaymentSession =
       sdkInstance.createApplePayOneTimePaymentSession();
 
-    document.getElementById("apple-pay-button-container").innerHTML =
-      '<apple-pay-button id="apple-pay-button" buttonstyle="black" type="buy" locale="en">';
+    const applePayButton = createApplePayButton();
+    applePayButton.addEventListener("click", onClick);
     document
-      .getElementById("apple-pay-button")
-      .addEventListener("click", onClick);
+      .getElementById("apple-pay-button-container")
+      .appendChild(applePayButton);
 
     async function onClick() {
       const paymentRequest = {
@@ -150,6 +150,20 @@ async function setupApplePayButton(sdkInstance, applePayPaymentMethodDetails) {
   } catch (error) {
     console.error(error);
   }
+}
+
+function createApplePayButton() {
+  const applePayButton = document.createElement("apple-pay-button");
+  applePayButton.id = "apple-pay-button";
+  applePayButton.setAttribute("buttonstyle", "black");
+  applePayButton.setAttribute("type", "buy");
+  applePayButton.setAttribute("locale", "en-US");
+
+  applePayButton.style.setProperty("--apple-pay-button-width", "150px");
+  applePayButton.style.setProperty("--apple-pay-button-height", "40px");
+  applePayButton.style.setProperty("--apple-pay-button-border-radius", "5px");
+
+  return applePayButton;
 }
 
 async function getBrowserSafeClientId() {


### PR DESCRIPTION
This PR removes the note about recommending clientToken for security with ApplePay. It also refactors the apple-pay button creation to avoid using `innerHTML`