### PR TITLE
added google pay to example repo

### DIFF
--- a/client/prebuiltPages/react/README.md
+++ b/client/prebuiltPages/react/README.md
@@ -2,9 +2,9 @@
 
 > **SDK Version**: PayPal JS SDK v6
 > **Framework**: React 19.2.4 + TypeScript
-> **Frontend Package**: @paypal/react-paypal-js v9.0.1
+> **Frontend Package**: @paypal/react-paypal-js v10.0.0
 > **Backend Package**: @paypal/paypal-server-sdk v2.1.0
-> **Payment Methods**: PayPal, Venmo, Pay Later, Guest Card, Subscriptions, Save, Credit, Apple Pay
+> **Payment Methods**: PayPal, Venmo, Pay Later, Guest Card, Subscriptions, Save, Credit, Apple Pay, Google Pay
 > **Demo**: Multi-page checkout flows with routing
 
 This React sample application demonstrates how to integrate different PayPal payment flows using PayPal's React component library, `react-paypal-js`.
@@ -30,6 +30,7 @@ Browse all available examples at the [Examples Index](https://v6-web-sdk-sample-
 - **PayPal Save** - Vault payment methods without purchase
 - **PayPal Credit** - PayPal Credit one-time and save payments
 - **Apple Pay** - Native Apple Pay one-time payment flow in Safari
+- **Google Pay** - Native Google Pay one-time payment flow in Chrome and other modern browsers
 
 ## Technology Stack
 
@@ -39,7 +40,7 @@ Browse all available examples at the [Examples Index](https://v6-web-sdk-sample-
 | Vite                      | 7.3.1   | Development server and bundler                     |
 | TypeScript                | 5.9.3   | Type safety                                        |
 | React Router DOM          | 7.13.0  | Client-side routing                                |
-| @paypal/react-paypal-js   | 9.0.1   | React hooks and Context provider for PayPal V6 SDK |
+| @paypal/react-paypal-js   | 10.0.0  | React hooks and Context provider for PayPal V6 SDK |
 | @paypal/paypal-server-sdk | 2.1.0   | Server-side PayPal API calls                       |
 | react-error-boundary      | 6.1.0   | Error boundary component for React                 |
 
@@ -89,6 +90,9 @@ The Vite dev server proxies `/paypal-api` requests to the backend server on port
 | `/one-time-payment/apple-pay`            | Apple Pay one-time payment product page          |
 | `/one-time-payment/apple-pay/cart`       | Apple Pay one-time payment cart page             |
 | `/one-time-payment/apple-pay/checkout`   | Apple Pay one-time payment checkout              |
+| `/one-time-payment/google-pay`           | Google Pay one-time payment product page         |
+| `/one-time-payment/google-pay/cart`      | Google Pay one-time payment cart page            |
+| `/one-time-payment/google-pay/checkout`  | Google Pay one-time payment checkout             |
 | `/save-payment`                          | Save Payment (Vault only) payment method page    |
 | `/save-payment/card-fields`              | Card Fields Save Payment method page             |
 | `/subscription`                          | Subscription product page                        |
@@ -148,6 +152,7 @@ react/
 │   │   ├── OneTimePaymentCheckout.tsx  # One-Time Payment checkout wrapper
 │   │   ├── CardFieldsOneTimePaymentCheckout.tsx # Card Fields One-Time Payment wrapper
 │   │   ├── ApplePayOneTimePaymentCheckout.tsx # Apple Pay one-time payment wrapper
+│   │   ├── GooglePayOneTimePaymentCheckout.tsx # Google Pay one-time payment wrapper
 │   │   ├── VaultWithPurchaseCheckout.tsx # Vault with Purchase checkout wrapper
 │   │   └── SubscriptionCheckout.tsx    # Subscription checkout wrapper
 │   ├── paypalMessages/                 # PayPal Messages feature
@@ -205,6 +210,7 @@ The `components` prop specifies which payment methods and features to load:
 - `card-fields` - Card Fields (advanced card payment UI)
 - `paypal-messages` - PayPal Messages promotional component
 - `applepay-payments` - Apple Pay button and one-time payment session support
+- `googlepay-payments` - Google Pay button and one-time payment session support
 
 ### Apple Pay Requirements
 
@@ -220,6 +226,17 @@ The Apple Pay demo requires:
   crossorigin
   src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"
 ></script>
+```
+
+### Google Pay Requirements
+
+The Google Pay demo requires:
+
+1. Chrome or another modern browser that supports the Google Pay API
+2. Google Pay JS loaded in `index.html` (must execute before the React bundle so `window.google.payments.api` is available when `useGooglePayOneTimePaymentSession` mounts)
+
+```html
+<script defer src="https://pay.google.com/gp/p/js/pay.js"></script>
 ```
 
 ### 2. Eligibility
@@ -327,6 +344,7 @@ Each payment button uses a specialized hook to create a payment session:
 | `useVenmoOneTimePaymentSession`        | Venmo               |
 | `usePayLaterOneTimePaymentSession`     | Pay Later           |
 | `useApplePayOneTimePaymentSession`     | Apple Pay           |
+| `useGooglePayOneTimePaymentSession`    | Google Pay          |
 | `usePayPalGuestPaymentSession`         | Basic Card          |
 | `usePayPalSubscriptionPaymentSession`  | Subscriptions       |
 | `usePayPalSavePaymentSession`          | Save Payment Method |
@@ -439,6 +457,15 @@ const CardFieldsPayment = () => {
 5. `validateMerchant` and `confirmOrder` are handled by `useApplePayOneTimePaymentSession` internally
 6. In `onApprove`, capture with `data.approveApplePayPayment.id`
 
+### 4.3 Payment Flow - Google Pay
+
+1. Fetch eligibility/config with `useEligibleMethods` for `ONE_TIME_PAYMENT`
+2. Read the raw config via `eligiblePaymentMethods.getDetails("googlepay").config` (the React component formats it internally)
+3. Render `GooglePayOneTimePaymentButton` with `googlePayConfig` and a `transactionInfo` payload
+4. On button click, `createOrder` runs to create the PayPal order
+5. The Google Pay payment sheet opens; on authorization, `useGooglePayOneTimePaymentSession` confirms the order with PayPal
+6. In `onApprove`, capture with `data.id` (unless `status === "PAYER_ACTION_REQUIRED"`, which signals 3DS)
+
 ## Backend Server
 
 The Node.js backend handles sensitive PayPal API interactions.
@@ -479,6 +506,7 @@ The Node.js backend handles sensitive PayPal API interactions.
 
 - [PayPal JS SDK V6 Documentation](https://docs.paypal.ai/payments/methods/paypal/sdk/js/v6/paypal-checkout)
 - [PayPal JS SDK V6 Apple Pay Documentation](https://docs.paypal.ai/payments/methods/digital-wallets/apple-pay)
+- [PayPal JS SDK V6 Google Pay Documentation](https://docs.paypal.ai/payments/methods/digital-wallets/google-pay)
 - [@paypal/react-paypal-js on npm](https://www.npmjs.com/package/@paypal/react-paypal-js)
 - [@paypal/paypal-server-sdk on GitHub](https://github.com/paypal/PayPal-TypeScript-Server-SDK)
 - [PayPal Developer Dashboard](https://developer.paypal.com/dashboard/)
@@ -555,7 +583,7 @@ import { INSTANCE_LOADING_STATE } from "@paypal/react-paypal-js/sdk-v6";
 
 | Package                   | Version | Purpose                                            |
 | ------------------------- | ------- | -------------------------------------------------- |
-| @paypal/react-paypal-js   | 9.0.1   | React hooks and Context provider for PayPal V6 SDK |
+| @paypal/react-paypal-js   | 10.0.0  | React hooks and Context provider for PayPal V6 SDK |
 | @paypal/paypal-server-sdk | 2.1.0   | Server-side PayPal API calls                       |
 | react-router-dom          | 7.13.0  | Client-side routing                                |
 | react-error-boundary      | 6.1.0   | Error boundary wrapper for error handling          |

--- a/client/prebuiltPages/react/index.html
+++ b/client/prebuiltPages/react/index.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script async src="https://pay.google.com/gp/p/js/pay.js"></script>
+    <script src="https://pay.google.com/gp/p/js/pay.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/client/prebuiltPages/react/index.html
+++ b/client/prebuiltPages/react/index.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://pay.google.com/gp/p/js/pay.js"></script>
+    <script defer src="https://pay.google.com/gp/p/js/pay.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/client/prebuiltPages/react/index.html
+++ b/client/prebuiltPages/react/index.html
@@ -15,6 +15,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script async src="https://pay.google.com/gp/p/js/pay.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/client/prebuiltPages/react/package-lock.json
+++ b/client/prebuiltPages/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "paypal-sdk-v6-react-demos",
       "version": "1.0.0",
       "dependencies": {
-        "@paypal/react-paypal-js": "^9.2.0",
+        "@paypal/react-paypal-js": "^10.0.0",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-error-boundary": "6.1.1",
@@ -615,21 +615,21 @@
       "license": "MIT"
     },
     "node_modules/@paypal/paypal-js": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-9.7.0.tgz",
-      "integrity": "sha512-eUQVZWTEhXhaPsYDmfUaOeV5zfeLUn7kCE7/BXm6uAtMhUoK0S7uPtUzosqfH1vZgjfUSyTzghDJtYxXyRRZig==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-10.0.0.tgz",
+      "integrity": "sha512-IOAA8Ls7A5WXH8vV8Lbh+QTyVsQWbmqzCMvNFmGO/56D+7i5OMXhjzG2Qhz0WHSiVe+IutqJMWPX2dHJXA7Kgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "promise-polyfill": "^8.3.0"
       }
     },
     "node_modules/@paypal/react-paypal-js": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-9.2.0.tgz",
-      "integrity": "sha512-wckuxilT+fYYwg0TYbEbxkclYeJnhIlThpNtV9RLXQA6uBbt5xPIzGv9wt2ykQTLiNIqhXhw1Hlz5yxUeCteKQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-10.0.0.tgz",
+      "integrity": "sha512-65ry+7rJE2sjwPGrW2pSPM8ye2pYxIFO/DpAd0QfkJ56FHc281paAHc5OTg/cZf88UUXkn7hltLDZ60CRfjIrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@paypal/paypal-js": "^9.7.0",
+        "@paypal/paypal-js": "^10.0.0",
         "@paypal/sdk-constants": "^1.0.122",
         "server-only": "^0.0.1"
       },

--- a/client/prebuiltPages/react/package.json
+++ b/client/prebuiltPages/react/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --build --noEmit"
   },
   "dependencies": {
-    "@paypal/react-paypal-js": "^9.2.0",
+    "@paypal/react-paypal-js": "^10.0.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-error-boundary": "6.1.1",

--- a/client/prebuiltPages/react/src/App.tsx
+++ b/client/prebuiltPages/react/src/App.tsx
@@ -97,6 +97,7 @@ function App() {
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <PayPalProvider
         clientId={clientId}
+        environment="sandbox"
         components={[
           "paypal-payments",
           "venmo-payments",

--- a/client/prebuiltPages/react/src/App.tsx
+++ b/client/prebuiltPages/react/src/App.tsx
@@ -12,6 +12,7 @@ import BaseCart from "./pages/BaseCart";
 import OneTimeCheckoutPage from "./paymentFlowCheckoutPages/OneTimePaymentCheckout";
 import CardFieldsOneTimePaymentCheckout from "./paymentFlowCheckoutPages/CardFieldsOneTimePaymentCheckout";
 import ApplePayOneTimePaymentCheckout from "./paymentFlowCheckoutPages/ApplePayOneTimePaymentCheckout";
+import GooglePayOneTimePaymentCheckout from "./paymentFlowCheckoutPages/GooglePayOneTimePaymentCheckout";
 
 // One-Time Payment with Vault flow
 import VaultWithPurchaseCheckoutPage from "./paymentFlowCheckoutPages/VaultWithPurchaseCheckout";
@@ -104,6 +105,7 @@ function App() {
           "card-fields",
           "paypal-messages",
           "applepay-payments",
+          "googlepay-payments",
         ]}
         pageType="checkout"
       >
@@ -173,6 +175,28 @@ function App() {
             <Route
               path="/one-time-payment/apple-pay/checkout"
               element={<ApplePayOneTimePaymentCheckout />}
+            />
+            <Route
+              path="/one-time-payment/google-pay"
+              element={
+                <BaseProduct
+                  flowType="one-time-payment"
+                  paymentMethod="google-pay"
+                />
+              }
+            />
+            <Route
+              path="/one-time-payment/google-pay/cart"
+              element={
+                <BaseCart
+                  flowType="one-time-payment"
+                  paymentMethod="google-pay"
+                />
+              }
+            />
+            <Route
+              path="/one-time-payment/google-pay/checkout"
+              element={<GooglePayOneTimePaymentCheckout />}
             />
 
             {/* One-Time Payment with Vault flow */}

--- a/client/prebuiltPages/react/src/pages/BaseCart.tsx
+++ b/client/prebuiltPages/react/src/pages/BaseCart.tsx
@@ -10,7 +10,7 @@ interface CartPageProps {
     | "save-payment"
     | "subscription"
     | "vault-with-purchase";
-  paymentMethod?: "card-fields" | "apple-pay";
+  paymentMethod?: "card-fields" | "apple-pay" | "google-pay";
 }
 
 const BaseCart = ({ flowType, paymentMethod }: CartPageProps) => {

--- a/client/prebuiltPages/react/src/pages/BaseProduct.tsx
+++ b/client/prebuiltPages/react/src/pages/BaseProduct.tsx
@@ -10,7 +10,7 @@ interface ProductPageProps {
     | "save-payment"
     | "subscription"
     | "vault-with-purchase";
-  paymentMethod?: "card-fields" | "apple-pay";
+  paymentMethod?: "card-fields" | "apple-pay" | "google-pay";
 }
 
 const BaseProduct = ({ flowType, paymentMethod }: ProductPageProps) => {

--- a/client/prebuiltPages/react/src/pages/Home.tsx
+++ b/client/prebuiltPages/react/src/pages/Home.tsx
@@ -189,8 +189,9 @@ export function HomePage() {
                     lineHeight: "1.6",
                   }}
                 >
-                  Google Pay checkout using the PayPal SDK with native Google Pay
-                  button integration. Works in Chrome and most modern browsers.
+                  Google Pay checkout using the PayPal SDK with native Google
+                  Pay button integration. Works in Chrome and most modern
+                  browsers.
                 </td>
               </tr>
               <tr

--- a/client/prebuiltPages/react/src/pages/Home.tsx
+++ b/client/prebuiltPages/react/src/pages/Home.tsx
@@ -170,6 +170,40 @@ export function HomePage() {
                   }}
                 >
                   <Link
+                    to="/one-time-payment/google-pay"
+                    style={{
+                      color: "#0070ba",
+                      textDecoration: "none",
+                      fontSize: "16px",
+                      fontWeight: "500",
+                    }}
+                  >
+                    One-Time Payment: Google Pay
+                  </Link>
+                </td>
+                <td
+                  style={{
+                    padding: "16px",
+                    color: "#4a5568",
+                    fontSize: "14px",
+                    lineHeight: "1.6",
+                  }}
+                >
+                  Google Pay checkout using the PayPal SDK with native Google Pay
+                  button integration. Works in Chrome and most modern browsers.
+                </td>
+              </tr>
+              <tr
+                style={{
+                  borderBottom: "1px solid #e2e8f0",
+                }}
+              >
+                <td
+                  style={{
+                    padding: "16px",
+                  }}
+                >
+                  <Link
                     to="/vault-with-purchase"
                     style={{
                       color: "#0070ba",

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/GooglePayOneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/GooglePayOneTimePaymentCheckout.tsx
@@ -10,6 +10,12 @@ import BaseCheckout from "../pages/BaseCheckout";
 import type { ModalType, ModalContent, ProductItem } from "../types";
 import { captureOrder, createOrder } from "../utils";
 
+/**
+ * Checkout page for one-time payments using Google Pay.
+ *
+ * Uses useEligibleMethods to fetch Google Pay config, then renders
+ * GooglePayOneTimePaymentButton which handles the full payment lifecycle.
+ */
 const GooglePayOneTimePaymentCheckout = () => {
   const [modalState, setModalState] = useState<ModalType>(null);
   const { loadingStatus } = usePayPal();
@@ -19,6 +25,7 @@ const GooglePayOneTimePaymentCheckout = () => {
     useEligibleMethods({
       payload: {
         currencyCode: "USD",
+        paymentFlow: "ONE_TIME_PAYMENT",
       },
     });
 
@@ -137,7 +144,7 @@ const GooglePayOneTimePaymentCheckout = () => {
     <div>
       <GooglePayOneTimePaymentButton
         googlePayConfig={googlePayConfig}
-        transactionInfo={getGoogleTransactionInfo(getCartTotal(), "US")}
+        transactionInfo={getGoogleTransactionInfo(getCartTotal(), googlePayConfig.merchantCountry)}
         environment="TEST"
         createOrder={handleCreateOrder}
         onApprove={async (data) => {

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/GooglePayOneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/GooglePayOneTimePaymentCheckout.tsx
@@ -144,7 +144,10 @@ const GooglePayOneTimePaymentCheckout = () => {
     <div>
       <GooglePayOneTimePaymentButton
         googlePayConfig={googlePayConfig}
-        transactionInfo={getGoogleTransactionInfo(getCartTotal(), googlePayConfig.merchantCountry)}
+        transactionInfo={getGoogleTransactionInfo(
+          getCartTotal(),
+          googlePayConfig.merchantCountry,
+        )}
         environment="TEST"
         createOrder={handleCreateOrder}
         onApprove={async (data) => {

--- a/client/prebuiltPages/react/src/paymentFlowCheckoutPages/GooglePayOneTimePaymentCheckout.tsx
+++ b/client/prebuiltPages/react/src/paymentFlowCheckoutPages/GooglePayOneTimePaymentCheckout.tsx
@@ -1,0 +1,184 @@
+import { useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  usePayPal,
+  useEligibleMethods,
+  INSTANCE_LOADING_STATE,
+  GooglePayOneTimePaymentButton,
+} from "@paypal/react-paypal-js/sdk-v6";
+import BaseCheckout from "../pages/BaseCheckout";
+import type { ModalType, ModalContent, ProductItem } from "../types";
+import { captureOrder, createOrder } from "../utils";
+
+const GooglePayOneTimePaymentCheckout = () => {
+  const [modalState, setModalState] = useState<ModalType>(null);
+  const { loadingStatus } = usePayPal();
+  const navigate = useNavigate();
+
+  const { eligiblePaymentMethods, error: eligibilityError } =
+    useEligibleMethods({
+      payload: {
+        currencyCode: "USD",
+      },
+    });
+
+  const googlePayConfig = eligiblePaymentMethods?.isEligible("googlepay")
+    ? eligiblePaymentMethods.getDetails("googlepay").config
+    : null;
+
+  const getCartProducts = (): ProductItem[] => {
+    const savedCart = sessionStorage.getItem("cart");
+    return savedCart ? JSON.parse(savedCart) : [];
+  };
+
+  const getCartTotal = (): string => {
+    const products = getCartProducts();
+    const total = products.reduce((sum, item) => {
+      if (item.price !== undefined) {
+        return sum + item.price * item.quantity;
+      }
+      return sum;
+    }, 0);
+    return total.toFixed(2);
+  };
+
+  const getGoogleTransactionInfo = useCallback(
+    (purchaseAmount: string, countryCode: string) => {
+      const totalAmount = parseFloat(purchaseAmount);
+      const subtotal = (totalAmount * 0.9).toFixed(2);
+      const tax = (totalAmount * 0.1).toFixed(2);
+
+      return {
+        displayItems: [
+          {
+            label: "Subtotal",
+            type: "SUBTOTAL",
+            price: subtotal,
+          },
+          {
+            label: "Tax",
+            type: "TAX",
+            price: tax,
+          },
+        ],
+        countryCode,
+        currencyCode: "USD",
+        totalPriceStatus: "FINAL" as const,
+        totalPrice: purchaseAmount,
+        totalPriceLabel: "Total",
+      };
+    },
+    [],
+  );
+
+  const handleCreateOrder = async () => {
+    const products = getCartProducts();
+
+    const cart = products.map((product) => ({
+      sku: product.sku,
+      quantity: product.quantity,
+    }));
+
+    return await createOrder(cart);
+  };
+
+  const getModalContent = useCallback(
+    (state: ModalType): ModalContent | null => {
+      switch (state) {
+        case "success":
+          return {
+            title: "Payment Successful! 🎉",
+            message: "Thank you for your Google Pay purchase!",
+          };
+        case "cancel":
+          return {
+            title: "Payment Cancelled",
+            message: "Your Google Pay payment was cancelled.",
+          };
+        case "error":
+          return {
+            title: "Payment Error",
+            message:
+              "There was an error processing your Google Pay payment. Please try again.",
+          };
+        default:
+          return null;
+      }
+    },
+    [],
+  );
+
+  const isLoading = loadingStatus === INSTANCE_LOADING_STATE.PENDING;
+
+  const handleModalClose = () => {
+    setModalState(null);
+    if (modalState === "success") {
+      navigate("/");
+    }
+  };
+
+  const paymentButtons = isLoading ? (
+    <div style={{ padding: "1rem", textAlign: "center" }}>
+      Loading payment methods...
+    </div>
+  ) : eligibilityError ? (
+    <div style={{ padding: "1rem", textAlign: "center", color: "red" }}>
+      Failed to load payment options. Please refresh the page.
+    </div>
+  ) : !eligiblePaymentMethods ? (
+    <div style={{ padding: "1rem", textAlign: "center" }}>
+      Loading payment methods...
+    </div>
+  ) : !eligiblePaymentMethods.isEligible("googlepay") ? (
+    <div style={{ padding: "1rem", textAlign: "center", color: "#856404" }}>
+      Google Pay is not eligible for this transaction.
+    </div>
+  ) : googlePayConfig ? (
+    <div>
+      <GooglePayOneTimePaymentButton
+        googlePayConfig={googlePayConfig}
+        transactionInfo={getGoogleTransactionInfo(getCartTotal(), "US")}
+        environment="TEST"
+        createOrder={handleCreateOrder}
+        onApprove={async (data) => {
+          console.log("Google Pay payment approved:", data);
+
+          if (data.status !== "PAYER_ACTION_REQUIRED") {
+            const captureResult = await captureOrder({ orderId: data.id });
+            console.log("Google Pay capture result:", captureResult);
+          }
+
+          sessionStorage.removeItem("cart");
+          setModalState("success");
+        }}
+        onCancel={() => {
+          console.log("Google Pay payment cancelled");
+          setModalState("cancel");
+        }}
+        onError={(error) => {
+          console.error("Google Pay payment error:", error);
+          setModalState("error");
+        }}
+        buttonType="pay"
+        buttonColor="default"
+        buttonSizeMode="fill"
+      />
+    </div>
+  ) : (
+    <div style={{ padding: "1rem", textAlign: "center" }}>
+      Loading Google Pay configuration...
+    </div>
+  );
+
+  return (
+    <BaseCheckout
+      flowType="one-time-payment"
+      modalState={modalState}
+      onModalClose={handleModalClose}
+      getModalContent={getModalContent}
+      paymentButtons={paymentButtons}
+    />
+  );
+};
+
+export default GooglePayOneTimePaymentCheckout;


### PR DESCRIPTION
Adds a Google Pay one-time-payment demo to the React prebuilt pages.

**Note:** This PR bumps `@paypal/react-paypal-js` from `^9.2.0` to `^10.0.0` because `GooglePayOneTimePaymentButton` is only exported in v10. v10's `PayPalProvider` also requires the new `environment` prop, which has been added.

https://github.com/user-attachments/assets/3d9ec4ed-60d6-4bb4-a89f-ce46a9c1cf75