### PR TITLE
Bump react-paypal-js and paypal-js

### DIFF
--- a/client/components/paypalPayments/oneTimePayment/typescript/package-lock.json
+++ b/client/components/paypalPayments/oneTimePayment/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@paypal/paypal-js": "^9.7.0"
+        "@paypal/paypal-js": "^10.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -744,9 +744,9 @@
       }
     },
     "node_modules/@paypal/paypal-js": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-9.7.0.tgz",
-      "integrity": "sha512-eUQVZWTEhXhaPsYDmfUaOeV5zfeLUn7kCE7/BXm6uAtMhUoK0S7uPtUzosqfH1vZgjfUSyTzghDJtYxXyRRZig==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-10.0.0.tgz",
+      "integrity": "sha512-IOAA8Ls7A5WXH8vV8Lbh+QTyVsQWbmqzCMvNFmGO/56D+7i5OMXhjzG2Qhz0WHSiVe+IutqJMWPX2dHJXA7Kgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "promise-polyfill": "^8.3.0"

--- a/client/components/paypalPayments/oneTimePayment/typescript/package.json
+++ b/client/components/paypalPayments/oneTimePayment/typescript/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "description": "",
   "dependencies": {
-    "@paypal/paypal-js": "^9.7.0"
+    "@paypal/paypal-js": "^10.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/client/prebuiltPages/react/package-lock.json
+++ b/client/prebuiltPages/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "paypal-sdk-v6-react-demos",
       "version": "1.0.0",
       "dependencies": {
-        "@paypal/react-paypal-js": "^9.2.0",
+        "@paypal/react-paypal-js": "^10.0.0",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-error-boundary": "6.1.1",
@@ -615,21 +615,21 @@
       "license": "MIT"
     },
     "node_modules/@paypal/paypal-js": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-9.7.0.tgz",
-      "integrity": "sha512-eUQVZWTEhXhaPsYDmfUaOeV5zfeLUn7kCE7/BXm6uAtMhUoK0S7uPtUzosqfH1vZgjfUSyTzghDJtYxXyRRZig==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-10.0.0.tgz",
+      "integrity": "sha512-IOAA8Ls7A5WXH8vV8Lbh+QTyVsQWbmqzCMvNFmGO/56D+7i5OMXhjzG2Qhz0WHSiVe+IutqJMWPX2dHJXA7Kgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "promise-polyfill": "^8.3.0"
       }
     },
     "node_modules/@paypal/react-paypal-js": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-9.2.0.tgz",
-      "integrity": "sha512-wckuxilT+fYYwg0TYbEbxkclYeJnhIlThpNtV9RLXQA6uBbt5xPIzGv9wt2ykQTLiNIqhXhw1Hlz5yxUeCteKQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-10.0.0.tgz",
+      "integrity": "sha512-65ry+7rJE2sjwPGrW2pSPM8ye2pYxIFO/DpAd0QfkJ56FHc281paAHc5OTg/cZf88UUXkn7hltLDZ60CRfjIrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@paypal/paypal-js": "^9.7.0",
+        "@paypal/paypal-js": "^10.0.0",
         "@paypal/sdk-constants": "^1.0.122",
         "server-only": "^0.0.1"
       },

--- a/client/prebuiltPages/react/package.json
+++ b/client/prebuiltPages/react/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --build --noEmit"
   },
   "dependencies": {
-    "@paypal/react-paypal-js": "^9.2.0",
+    "@paypal/react-paypal-js": "^10.0.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-error-boundary": "6.1.1",

--- a/client/prebuiltPages/react/src/App.tsx
+++ b/client/prebuiltPages/react/src/App.tsx
@@ -96,6 +96,7 @@ function App() {
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <PayPalProvider
         clientId={clientId}
+        environment="sandbox"
         components={[
           "paypal-payments",
           "venmo-payments",


### PR DESCRIPTION
Bumps the `react-paypal-js` and `paypal-js` packages to version 10 in the typescript and react sample integrations.