### PR TITLE
Iframe sandbox example with two separate sibling iframes

### DIFF
--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/merchant-example/two-iframe-approach.html
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/merchant-example/two-iframe-approach.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PayPal two iframe approach</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💸</text></svg>"
+    />
+
+    <style>
+      :root {
+        --theme-color-text: #0a1b0f;
+        --theme-color-background: #f7fcf9;
+        --theme-color-primary: #334037;
+        --theme-color-secondary: #93e3ab;
+        --theme-color-accent: #62dc87;
+        --theme-color-overlay-cta: #ffffff;
+        --theme-color-overlay-background: #000000aa;
+        --theme-color-overlay-background-close-text: #cccccc;
+      }
+
+      body {
+        margin: 0;
+        font-family: sans-serif;
+        color: var(--theme-color-text);
+      }
+
+      button {
+        border: none;
+        font-size: 1em;
+        padding: 10px;
+        border-radius: 5px;
+      }
+
+      #stateDebug {
+        padding: 5px;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        background: var(--theme-color-secondary);
+        z-index: 100;
+      }
+
+      #mainContainer {
+        padding: 10px;
+      }
+
+      #extraHeight {
+        background: var(--theme-color-background);
+        height: 1000px;
+        width: 100%;
+      }
+
+      #overlayContainer {
+        background: none;
+        border: none;
+        overflow: visible;
+        text-align: center;
+      }
+
+      #overlayContainerLogo {
+        margin-bottom: 10px;
+      }
+
+      #overlayCloseButtonCTA {
+        background: var(--theme-color-overlay-cta);
+        cursor: pointer;
+        border-radius: 20px;
+        padding: 10px 20px;
+      }
+
+      #overlayCloseButtonBackdrop {
+        background: none;
+        color: var(--theme-color-overlay-background-close-text);
+        position: fixed;
+        top: 0;
+        right: 0;
+        font-size: 1.5em;
+        cursor: pointer;
+      }
+
+      #overlayContainer::backdrop {
+        background: var(--theme-color-overlay-background);
+      }
+
+      #iframeButton {
+        border: none;
+        width: 100%;
+        height: 300px;
+      }
+
+      #iframeModalContainer {
+        border: none;
+        width: 100%;
+        height: 100px;
+      }
+
+      #iframeModalContainer.fullWindow {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .stateValue {
+        font-family: monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <script async src="/two-iframe-approach.js" onload="onLoad()"></script>
+
+    <div id="mainContainer">
+      <h1>PayPal two iframe approach</h1>
+
+      <p>
+        The parent page is an example merchant page. Within the merchant page,
+        there are two different iframes that each use the PayPal Web SDK. One is
+        for the button and the second one is for the modal presentation mode
+        container. The merchant page and iframes communicate about the state of
+        the payment flow via postMessage.
+      </p>
+
+      <div id="stateDebug">
+        <div>Merchant Page State</div>
+        <li>
+          <span>merchant page domain:</span>
+          <span id="merchantDomain" class="stateValue"></span>
+        </li>
+        <li>
+          <span>last message from iframe: </span>
+          <span id="postMessageStatus" class="stateValue">No messages 😴</span>
+        </li>
+        <li>
+          <span>selected presentationMode from iframe: </span>
+          <span id="presentationMode" class="stateValue">Not set 🤔</span>
+        </li>
+      </div>
+
+      <iframe
+        id="iframeButton"
+        src="http://localhost:3000/button-iframe.html?origin=http://localhost:3001"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-downloads"
+        allow="payment"
+      ></iframe>
+
+      <iframe
+        id="iframeModalContainer"
+        src="http://localhost:3000/modal-container.html?origin=http://localhost:3001"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-downloads"
+        allow="payment"
+      ></iframe>
+
+      <div id="extraHeight">Some extra height follows...</div>
+    </div>
+
+    <dialog id="overlayContainer">
+      <div id="overlayContainerLogo">
+        <img
+          src="https://www.paypalobjects.com/js-sdk-logos/2.2.7/paypal-white.svg"
+        />
+      </div>
+      <button id="overlayCloseButtonCTA">Close</button>
+      <button id="overlayCloseButtonBackdrop">X</button>
+    </dialog>
+  </body>
+</html>

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/merchant-example/two-iframe-approach.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/merchant-example/two-iframe-approach.js
@@ -1,0 +1,133 @@
+class PageState {
+  state = {
+    presentationMode: null,
+    lastPostMessage: null,
+    merchantDomain: null,
+  };
+
+  constructor() {
+    this.merchantDomain = window.location.origin;
+  }
+
+  set presentationMode(value) {
+    this.state.presentationMode = value;
+    const element = document.getElementById("presentationMode");
+    element.innerHTML = value;
+  }
+
+  get presentationMode() {
+    return this.state.presentationMode;
+  }
+
+  set lastPostMessage(event) {
+    const statusContainer = document.getElementById("postMessageStatus");
+    statusContainer.innerHTML = JSON.stringify(event.data);
+    this.state.lastPostMessage = event;
+  }
+
+  get lastPostMessage() {
+    return this.state.lastPostMessage;
+  }
+
+  set merchantDomain(value) {
+    document.getElementById("merchantDomain").innerHTML = value;
+    this.state.merchantDomain = value;
+  }
+}
+
+const pageState = new PageState();
+
+function popupPresentationModePostMessageHandler(event) {
+  const { eventName, data } = event.data;
+  const overlay = document.getElementById("overlayContainer");
+
+  if (eventName === "payment-flow-popup-start") {
+    overlay.showModal();
+  } else if (eventName === "payment-flow-popup-approved") {
+    overlay.close();
+  } else if (eventName === "payment-flow-popup-canceled") {
+    overlay.close();
+  } else if (eventName === "payment-flow-popup-errored") {
+    overlay.close();
+  } else if (eventName === "payment-flow-popup-failed-to-open") {
+    overlay.close();
+    pageState.presentationMode = "modal";
+    sendPostMessageToChildModalContainerIframe({
+      eventName: "payment-flow-modal-start",
+      data,
+    });
+    const iframe = document.getElementById("iframeModalContainer");
+    iframe.classList.add("fullWindow");
+  }
+}
+
+function modalPresentationModePostMessageHandler(event) {
+  const { eventName, data } = event.data;
+  const iframe = document.getElementById("iframeModalContainer");
+
+  if (eventName === "payment-flow-modal-approved") {
+    iframe.classList.remove("fullWindow");
+  } else if (eventName === "payment-flow-modal-canceled") {
+    iframe.classList.remove("fullWindow");
+  } else if (eventName === "payment-flow-modal-errored") {
+    iframe.classList.remove("fullWindow");
+  }
+}
+
+function setupPostMessageListener() {
+  window.addEventListener("message", (event) => {
+    // It's very important to check that the `origin` is expected to prevent XSS attacks!
+    if (event.origin !== "http://localhost:3000") {
+      return;
+    }
+
+    pageState.lastPostMessage = event;
+    const { eventName, data } = event.data;
+
+    if (eventName.startsWith("payment-flow-popup")) {
+      pageState.presentationMode = "popup";
+      popupPresentationModePostMessageHandler(event);
+    } else if (eventName.startsWith("payment-flow-modal")) {
+      pageState.presentationMode = "modal";
+      modalPresentationModePostMessageHandler(event);
+    }
+  });
+}
+
+function setupOverlay() {
+  const overlay = document.getElementById("overlayContainer");
+
+  const hideOverlay = () => {
+    overlay.close();
+    sendPostMessageToChildButtonIframe({ eventName: "close-payment-window" });
+  };
+
+  const closeCTA = document.getElementById("overlayCloseButtonCTA");
+  closeCTA.addEventListener("click", hideOverlay);
+
+  const closeBackdrop = document.getElementById("overlayCloseButtonBackdrop");
+  closeBackdrop.addEventListener("click", hideOverlay);
+}
+
+function onLoad() {
+  if (window.setupComplete) {
+    return;
+  }
+
+  setupOverlay();
+  setupPostMessageListener();
+
+  window.setupComplete = true;
+}
+
+function sendPostMessageToChildButtonIframe(payload) {
+  const iframe = document.getElementById("iframeButton");
+  const childOrigin = new URL(iframe.getAttribute("src")).origin;
+  iframe.contentWindow.postMessage(payload, childOrigin);
+}
+
+function sendPostMessageToChildModalContainerIframe(payload) {
+  const iframe = document.getElementById("iframeModalContainer");
+  const childOrigin = new URL(iframe.getAttribute("src")).origin;
+  iframe.contentWindow.postMessage(payload, childOrigin);
+}

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/button-iframe.html
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/button-iframe.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PayPal Payment Handler</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <style>
+      :root {
+        --theme-color-text: #e5f5ea;
+        --theme-color-background: #334037;
+        --theme-color-primary: #becbc2;
+        --theme-color-secondary: #1c6d36;
+        --theme-color-accent: #239f48;
+      }
+
+      html {
+        background: var(--theme-color-background);
+      }
+
+      body {
+        font-family: sans-serif;
+        color: var(--theme-color-text);
+      }
+
+      .stateValue {
+        font-family: monospace;
+      }
+
+      #config {
+        padding-bottom: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stateDebug">
+      <div>Iframe Button Page State</div>
+      <ul>
+        <li>
+          <span>iframe domain:</span>
+          <span id="iframeDomain" class="stateValue"></span>
+        </li>
+        <li>
+          <span>last message from parent: </span>
+          <span id="postMessageStatus" class="stateValue">No messages 😴</span>
+        </li>
+      </ul>
+    </div>
+
+    <paypal-button id="paypal-button"></paypal-button>
+
+    <script src="/button-iframe.js"></script>
+
+    <script
+      async
+      src="https://www.sandbox.paypal.com/web-sdk/v6/core"
+      onload="onPayPalWebSdkLoaded()"
+    ></script>
+  </body>
+</html>

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/button-iframe.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/button-iframe.js
@@ -1,0 +1,187 @@
+class PageState {
+  state = {
+    paymentSession: null,
+  };
+
+  get paymentSession() {
+    return this.state.paymentSession;
+  }
+
+  set paymentSession(value) {
+    this.state.paymentSession = value;
+  }
+}
+
+const pageState = new PageState();
+
+function getParentOrigin() {
+  const parentOrigin = new URLSearchParams(window.location.search).get(
+    "origin",
+  );
+  return parentOrigin;
+}
+
+function setupPostMessageListener() {
+  window.addEventListener("message", (event) => {
+    // It's very important to check that the `origin` is expected to prevent XSS attacks!
+    if (event.origin !== getParentOrigin()) {
+      return;
+    }
+
+    const { eventName } = event.data;
+
+    const statusContainer = document.querySelector("#postMessageStatus");
+    statusContainer.innerHTML = JSON.stringify(event.data);
+
+    if (eventName === "close-payment-window") {
+      pageState.paymentSession?.cancel();
+    }
+  });
+}
+
+function sendPostMessageToParent(payload) {
+  window.parent.postMessage(payload, getParentOrigin());
+}
+
+function setupIframeOriginDisplay() {
+  const origin = window.location.origin;
+  document.querySelector("#iframeDomain").innerHTML = origin;
+}
+
+async function configurePayPalButton(sdkInstance) {
+  pageState.paymentSession = sdkInstance.createPayPalOneTimePaymentSession({
+    onApprove: async (data) => {
+      const orderData = await captureOrder({
+        orderId: data.orderId,
+      });
+
+      sendPostMessageToParent({
+        eventName: "payment-flow-popup-approved",
+        data: orderData,
+      });
+    },
+    onCancel: (data) => {
+      sendPostMessageToParent({
+        eventName: "payment-flow-popup-canceled",
+        data: {
+          orderId: data?.orderId,
+        },
+      });
+    },
+    onError: (data) => {
+      sendPostMessageToParent({
+        eventName: "payment-flow-popup-errored",
+        data: {
+          orderId: data?.orderId,
+        },
+      });
+    },
+  });
+
+  const paypalButton = document.querySelector("#paypal-button");
+  paypalButton.addEventListener("click", async () => {
+    const paymentFlowConfig = {
+      presentationMode: "popup",
+      fullPageOverlay: { enabled: false },
+    };
+
+    sendPostMessageToParent({
+      eventName: "payment-flow-popup-start",
+      data: { paymentFlowConfig },
+    });
+
+    let orderIdValue;
+
+    try {
+      // get the promise reference by invoking createOrder()
+      // do not await this async function since it can cause transient activation issues
+      const createOrderPromise = createOrder().then(({ orderId }) => {
+        orderIdValue = orderId;
+        return { orderId };
+      });
+
+      await pageState.paymentSession.start(
+        paymentFlowConfig,
+        createOrderPromise,
+      );
+    } catch (error) {
+      if (error.isRecoverable) {
+        sendPostMessageToParent({
+          eventName: "payment-flow-popup-failed-to-open",
+          data: {
+            isOrderIdKnown: Boolean(orderIdValue),
+            orderId: orderIdValue,
+          },
+        });
+      }
+
+      console.error(error);
+    }
+  });
+}
+
+async function onPayPalWebSdkLoaded() {
+  if (window.setupComplete) {
+    return;
+  }
+
+  setupIframeOriginDisplay();
+  setupPostMessageListener();
+
+  try {
+    const clientId = await getBrowserSafeClientId();
+    const sdkInstance = await window.paypal.createInstance({
+      clientId,
+      components: ["paypal-payments"],
+      pageType: "checkout",
+    });
+
+    configurePayPalButton(sdkInstance);
+  } catch (error) {
+    console.error(error);
+  }
+
+  window.setupComplete = true;
+}
+
+async function getBrowserSafeClientId() {
+  const response = await fetch("/paypal-api/auth/browser-safe-client-id", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  const { clientId } = await response.json();
+
+  return clientId;
+}
+
+async function createOrder() {
+  const response = await fetch(
+    "/paypal-api/checkout/orders/create-order-for-one-time-payment",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const { id } = await response.json();
+
+  return { orderId: id };
+}
+
+async function captureOrder({ orderId }) {
+  const response = await fetch(
+    `/paypal-api/checkout/orders/${orderId}/capture`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const data = await response.json();
+
+  return data;
+}

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/modal-container.html
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/modal-container.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PayPal Modal Container</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <style>
+      :root {
+        --theme-color-text: #e5f5ea;
+        --theme-color-background: rebeccapurple;
+        --theme-color-primary: #becbc2;
+        --theme-color-secondary: #1c6d36;
+        --theme-color-accent: #239f48;
+      }
+
+      html {
+        background: var(--theme-color-background);
+      }
+
+      body {
+        font-family: sans-serif;
+        color: var(--theme-color-text);
+      }
+
+      .stateValue {
+        font-family: monospace;
+      }
+
+      #config {
+        padding-bottom: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stateDebug">
+      <div>Iframe Modal ContainerPage State</div>
+      <ul>
+        <li>
+          <span>iframe domain:</span>
+          <span id="iframeDomain" class="stateValue"></span>
+        </li>
+        <li>
+          <span>last message from parent: </span>
+          <span id="postMessageStatus" class="stateValue">No messages 😴</span>
+        </li>
+      </ul>
+    </div>
+
+    <script src="/modal-container.js"></script>
+
+    <script
+      async
+      src="https://www.sandbox.paypal.com/web-sdk/v6/core"
+      onload="onPayPalWebSdkLoaded()"
+    ></script>
+  </body>
+</html>

--- a/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/modal-container.js
+++ b/client/components/paypalPayments/oneTimePayment/html/src/advanced/sandboxedIframe/src/paypal-iframe/modal-container.js
@@ -1,0 +1,185 @@
+class PageState {
+  state = {
+    paymentSession: null,
+  };
+
+  get paymentSession() {
+    return this.state.paymentSession;
+  }
+
+  set paymentSession(value) {
+    this.state.paymentSession = value;
+  }
+}
+
+const pageState = new PageState();
+
+function getParentOrigin() {
+  const parentOrigin = new URLSearchParams(window.location.search).get(
+    "origin",
+  );
+  return parentOrigin;
+}
+
+function setupPostMessageListener() {
+  window.addEventListener("message", (event) => {
+    // It's very important to check that the `origin` is expected to prevent XSS attacks!
+    if (event.origin !== getParentOrigin()) {
+      return;
+    }
+
+    const { eventName, data } = event.data;
+
+    const statusContainer = document.querySelector("#postMessageStatus");
+    statusContainer.innerHTML = JSON.stringify(event.data);
+
+    if (eventName === "payment-flow-modal-start") {
+      startModalPresentationMode(data?.orderId);
+    }
+  });
+}
+
+function sendPostMessageToParent(payload) {
+  window.parent.postMessage(payload, getParentOrigin());
+}
+
+function setupIframeOriginDisplay() {
+  const origin = window.location.origin;
+  document.querySelector("#iframeDomain").innerHTML = origin;
+}
+
+async function configurePayPalSession(sdkInstance) {
+  pageState.paymentSession = sdkInstance.createPayPalOneTimePaymentSession({
+    onApprove: async (data) => {
+      const orderData = await captureOrder({
+        orderId: data.orderId,
+      });
+
+      sendPostMessageToParent({
+        eventName: "payment-flow-modal-approved",
+        data: orderData,
+      });
+    },
+    onCancel: (data) => {
+      sendPostMessageToParent({
+        eventName: "payment-flow-modal-canceled",
+        data: {
+          orderId: data?.orderId,
+        },
+      });
+    },
+    onError: (data) => {
+      sendPostMessageToParent({
+        eventName: "payment-flow-modal-errored",
+        data: {
+          orderId: data?.orderId,
+        },
+      });
+    },
+  });
+}
+
+async function startModalPresentationMode(orderId) {
+  // reuse order id
+  if (orderId) {
+    try {
+      await pageState.paymentSession.start(
+        { presentationMode: "modal" },
+        Promise.resolve({ orderId }),
+      );
+    } catch (e) {
+      sendPostMessageToParent({
+        eventName: "payment-flow-modal-failed-to-open",
+      });
+
+      console.error(e);
+    }
+  } else {
+    try {
+      // get the promise reference by invoking createOrder()
+      // do not await this async function since it can cause transient activation issues
+      let orderIdValue;
+      const createOrderPromise = createOrder().then(({ orderId }) => {
+        orderIdValue = orderId;
+        return { orderId };
+      });
+
+      await pageState.paymentSession.start(
+        { presentationMode: "modal" },
+        createOrderPromise,
+      );
+    } catch (e) {
+      sendPostMessageToParent({
+        eventName: "payment-flow-modal-failed-to-open",
+      });
+
+      console.error(e);
+    }
+  }
+}
+
+async function onPayPalWebSdkLoaded() {
+  if (window.setupComplete) {
+    return;
+  }
+
+  setupIframeOriginDisplay();
+  setupPostMessageListener();
+
+  try {
+    const clientId = await getBrowserSafeClientId();
+    const sdkInstance = await window.paypal.createInstance({
+      clientId,
+      components: ["paypal-payments"],
+      pageType: "checkout",
+    });
+
+    configurePayPalSession(sdkInstance);
+  } catch (error) {
+    console.error(error);
+  }
+
+  window.setupComplete = true;
+}
+
+async function getBrowserSafeClientId() {
+  const response = await fetch("/paypal-api/auth/browser-safe-client-id", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  const { clientId } = await response.json();
+
+  return clientId;
+}
+
+async function createOrder() {
+  const response = await fetch(
+    "/paypal-api/checkout/orders/create-order-for-one-time-payment",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const { id } = await response.json();
+
+  return { orderId: id };
+}
+
+async function captureOrder({ orderId }) {
+  const response = await fetch(
+    `/paypal-api/checkout/orders/${orderId}/capture`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const data = await response.json();
+
+  return data;
+}


### PR DESCRIPTION
This PR demos how to use two separate iframes with the iframe sandbox integration pattern:
1. buttons iframe - includes the paypal button iframe
2. modal container iframe - can be hidden by default. launches the modal flow and grows to 100% width and height when the popup fails to open.
