### PR TITLE
chore: show success/failure alerts for card fields

### DIFF
--- a/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/app.js
+++ b/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/app.js
@@ -45,6 +45,7 @@ function setupCardFields(sdkInstance) {
   document.querySelector("#paypal-card-fields-expiry").appendChild(expiryField);
 
   const payButton = document.querySelector("#pay-button");
+  payButton.removeAttribute("hidden");
   payButton.addEventListener("click", () => onPayClick(cardFieldsInstance));
 }
 
@@ -60,12 +61,8 @@ async function onPayClick(cardFieldsInstance) {
 
     switch (state) {
       case "succeeded": {
-        const { orderId, ...liabilityShift } = data;
-        // 3DS may or may not have occurred; Use liabilityShift
-        // to determine if the payment should be captured
-
         const orderData = await captureOrder({
-          orderId: data.orderId,
+          orderId,
         });
 
         renderAlert({
@@ -73,7 +70,6 @@ async function onPayClick(cardFieldsInstance) {
           message: "Order successfully captured!",
         });
         console.log("Capture result", orderData);
-
         break;
       }
       case "canceled": {
@@ -85,11 +81,16 @@ async function onPayClick(cardFieldsInstance) {
         break;
       }
       case "failed": {
-        // Validation or processing failure. data.message may be present
+        // Validation or processing failure
         console.error("Card submission failed", data);
+
+        const { message, liabilityShift } = data;
         renderAlert({
           type: "danger",
-          message: `Validation or processing failure: ${data.message ?? ""}`,
+          message: liabilityShift
+          ? `Payment failed 3D Secure check: "liabilityShift: ${liabilityShift}"`
+          : `Validation or processing failure: ${message ?? ""}`
+
         });
         break;
       }

--- a/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/app.js
+++ b/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/app.js
@@ -10,14 +10,18 @@ async function onPayPalWebSdkLoaded() {
 
     const isCardFieldsEligible = paymentMethods.isEligible("advanced_cards");
     if (isCardFieldsEligible) {
-      await setupCardFields(sdkInstance);
+      setupCardFields(sdkInstance);
     }
-  } catch (err) {
-    console.error("SDK init failed", err);
+  } catch (error) {
+    renderAlert({
+      type: "danger",
+      message: "Failed to initialize the PayPal Web SDK",
+    });
+    console.error(error);
   }
 }
 
-async function setupCardFields(sdkInstance) {
+function setupCardFields(sdkInstance) {
   const cardFieldsInstance =
     sdkInstance.createCardFieldsOneTimePaymentSession();
 
@@ -46,7 +50,7 @@ async function setupCardFields(sdkInstance) {
 
 async function onPayClick(cardFieldsInstance) {
   try {
-    const orderId = await createOrder(); // returns a string id
+    const { orderId } = await createOrder();
 
     const { data, state } = await cardFieldsInstance.submit(orderId, {
       billingAddress: {
@@ -63,18 +67,30 @@ async function onPayClick(cardFieldsInstance) {
         const orderData = await captureOrder({
           orderId: data.orderId,
         });
-        // TODO: show success UI, redirect, etc.
+
+        renderAlert({
+          type: "success",
+          message: "Order successfully captured!",
+        });
+        console.log("Capture result", orderData);
+
         break;
       }
       case "canceled": {
         // Buyer dismissed 3DS modal or canceled the flow
-        // TODO: show non-blocking message & allow retry
+        renderAlert({
+          type: "warning",
+          message: "Payment canceled.",
+        });
         break;
       }
       case "failed": {
         // Validation or processing failure. data.message may be present
         console.error("Card submission failed", data);
-        // TODO: surface error to buyer, allow retry
+        renderAlert({
+          type: "danger",
+          message: `Validation or processing failure: ${data.message ?? ""}`,
+        });
         break;
       }
       default: {
@@ -82,9 +98,11 @@ async function onPayClick(cardFieldsInstance) {
         console.warn("Unhandled submit state", state, data);
       }
     }
-  } catch (err) {
-    console.error("Payment flow error", err);
-    // TODO: Show generic error and allow retry
+  } catch (error) {
+    renderAlert({
+      type: "danger",
+      message: `Payment flow error: ${error.message}`,
+    });
   }
 }
 
@@ -118,7 +136,7 @@ async function createOrder() {
   }
   const { id } = await response.json();
 
-  return id; // return the string orderId
+  return { orderId: id };
 }
 
 async function captureOrder({ orderId }) {
@@ -137,4 +155,14 @@ async function captureOrder({ orderId }) {
   const data = await response.json();
 
   return data;
+}
+
+function renderAlert({ type, message }) {
+  const alertComponentElement = document.querySelector("alert-component");
+  if (!alertComponentElement) {
+    return;
+  }
+
+  alertComponentElement.setAttribute("type", type);
+  alertComponentElement.innerText = message;
 }

--- a/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/app.js
+++ b/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/app.js
@@ -88,9 +88,8 @@ async function onPayClick(cardFieldsInstance) {
         renderAlert({
           type: "danger",
           message: liabilityShift
-          ? `Payment failed 3D Secure check: "liabilityShift: ${liabilityShift}"`
-          : `Validation or processing failure: ${message ?? ""}`
-
+            ? `Payment failed 3D Secure check: "liabilityShift: ${liabilityShift}"`
+            : `Validation or processing failure: ${message ?? ""}`,
         });
         break;
       }

--- a/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/index.html
+++ b/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/index.html
@@ -29,7 +29,7 @@
       <div class="card-field" id="paypal-card-fields-cvv"></div>
       <div class="card-field" id="paypal-card-fields-expiry"></div>
     </div>
-    <button id="pay-button" class="pay-button">Pay</button>
+    <button id="pay-button" class="pay-button" hidden>Pay</button>
     <alert-component></alert-component>
 
     <script src="app.js"></script>

--- a/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/index.html
+++ b/client/components/cardFields/oneTimePayment/html/src/advanced/threeDSecure/index.html
@@ -30,6 +30,8 @@
       <div class="card-field" id="paypal-card-fields-expiry"></div>
     </div>
     <button id="pay-button" class="pay-button">Pay</button>
+    <alert-component></alert-component>
+
     <script src="app.js"></script>
 
     <script
@@ -37,5 +39,7 @@
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
       onload="onPayPalWebSdkLoaded()"
     ></script>
+
+    <script async src="/client/shared/alert-component.js"></script>
   </body>
 </html>

--- a/client/components/cardFields/oneTimePayment/html/src/recommended/app.js
+++ b/client/components/cardFields/oneTimePayment/html/src/recommended/app.js
@@ -45,6 +45,7 @@ function setupCardFields(sdkInstance) {
   document.querySelector("#paypal-card-fields-expiry").appendChild(expiryField);
 
   const payButton = document.querySelector("#pay-button");
+  payButton.removeAttribute("hidden");
   payButton.addEventListener("click", () => onPayClick(cardFieldsInstance));
 }
 
@@ -60,12 +61,8 @@ async function onPayClick(cardFieldsInstance) {
 
     switch (state) {
       case "succeeded": {
-        const { orderId, ...liabilityShift } = data;
-        // 3DS may or may not have occurred; Use liabilityShift
-        // to determine if the payment should be captured
-
         const orderData = await captureOrder({
-          orderId: data.orderId,
+          orderId,
         });
 
         renderAlert({
@@ -73,7 +70,6 @@ async function onPayClick(cardFieldsInstance) {
           message: "Order successfully captured!",
         });
         console.log("Capture result", orderData);
-
         break;
       }
       case "canceled": {

--- a/client/components/cardFields/oneTimePayment/html/src/recommended/app.js
+++ b/client/components/cardFields/oneTimePayment/html/src/recommended/app.js
@@ -10,14 +10,18 @@ async function onPayPalWebSdkLoaded() {
 
     const isCardFieldsEligible = paymentMethods.isEligible("advanced_cards");
     if (isCardFieldsEligible) {
-      await setupCardFields(sdkInstance);
+      setupCardFields(sdkInstance);
     }
-  } catch (err) {
-    console.error("SDK init failed", err);
+  } catch (error) {
+    renderAlert({
+      type: "danger",
+      message: "Failed to initialize the PayPal Web SDK",
+    });
+    console.error(error);
   }
 }
 
-async function setupCardFields(sdkInstance) {
+function setupCardFields(sdkInstance) {
   const cardFieldsInstance =
     sdkInstance.createCardFieldsOneTimePaymentSession();
 
@@ -46,7 +50,7 @@ async function setupCardFields(sdkInstance) {
 
 async function onPayClick(cardFieldsInstance) {
   try {
-    const orderId = await createOrder(); // returns a string id
+    const { orderId } = await createOrder();
 
     const { data, state } = await cardFieldsInstance.submit(orderId, {
       billingAddress: {
@@ -63,18 +67,30 @@ async function onPayClick(cardFieldsInstance) {
         const orderData = await captureOrder({
           orderId: data.orderId,
         });
-        // TODO: show success UI, redirect, etc.
+
+        renderAlert({
+          type: "success",
+          message: "Order successfully captured!",
+        });
+        console.log("Capture result", orderData);
+
         break;
       }
       case "canceled": {
         // Buyer dismissed 3DS modal or canceled the flow
-        // TODO: show non-blocking message & allow retry
+        renderAlert({
+          type: "warning",
+          message: "Payment canceled.",
+        });
         break;
       }
       case "failed": {
         // Validation or processing failure. data.message may be present
         console.error("Card submission failed", data);
-        // TODO: surface error to buyer, allow retry
+        renderAlert({
+          type: "danger",
+          message: `Validation or processing failure: ${data.message ?? ""}`,
+        });
         break;
       }
       default: {
@@ -82,9 +98,11 @@ async function onPayClick(cardFieldsInstance) {
         console.warn("Unhandled submit state", state, data);
       }
     }
-  } catch (err) {
-    console.error("Payment flow error", err);
-    // TODO: Show generic error and allow retry
+  } catch (error) {
+    renderAlert({
+      type: "danger",
+      message: `Payment flow error: ${error.message}`,
+    });
   }
 }
 
@@ -118,7 +136,7 @@ async function createOrder() {
   }
   const { id } = await response.json();
 
-  return id; // return the string orderId
+  return { orderId: id };
 }
 
 async function captureOrder({ orderId }) {
@@ -137,4 +155,14 @@ async function captureOrder({ orderId }) {
   const data = await response.json();
 
   return data;
+}
+
+function renderAlert({ type, message }) {
+  const alertComponentElement = document.querySelector("alert-component");
+  if (!alertComponentElement) {
+    return;
+  }
+
+  alertComponentElement.setAttribute("type", type);
+  alertComponentElement.innerText = message;
 }

--- a/client/components/cardFields/oneTimePayment/html/src/recommended/index.html
+++ b/client/components/cardFields/oneTimePayment/html/src/recommended/index.html
@@ -26,6 +26,8 @@
       <div class="card-field" id="paypal-card-fields-expiry"></div>
     </div>
     <button id="pay-button" class="pay-button">Pay</button>
+    <alert-component></alert-component>
+
     <script src="app.js"></script>
 
     <script
@@ -33,5 +35,7 @@
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
       onload="onPayPalWebSdkLoaded()"
     ></script>
+
+    <script async src="/client/shared/alert-component.js"></script>
   </body>
 </html>

--- a/client/components/cardFields/oneTimePayment/html/src/recommended/index.html
+++ b/client/components/cardFields/oneTimePayment/html/src/recommended/index.html
@@ -25,7 +25,7 @@
       <div class="card-field" id="paypal-card-fields-cvv"></div>
       <div class="card-field" id="paypal-card-fields-expiry"></div>
     </div>
-    <button id="pay-button" class="pay-button">Pay</button>
+    <button id="pay-button" class="pay-button" hidden>Pay</button>
     <alert-component></alert-component>
 
     <script src="app.js"></script>

--- a/client/components/cardFields/savePayment/html/src/app.js
+++ b/client/components/cardFields/savePayment/html/src/app.js
@@ -13,7 +13,11 @@ async function onPayPalWebSdkLoaded() {
       setupCardFields(sdkInstance);
     }
   } catch (err) {
-    console.error("SDK init failed", err);
+    renderAlert({
+      type: "danger",
+      message: "Failed to initialize the PayPal Web SDK",
+    });
+    console.error(error);
   }
 }
 
@@ -54,7 +58,6 @@ async function onPayClick(cardFieldsInstance) {
         const { vaultSetupToken, ...liabilityShift } = data;
         // 3DS may or may not have occurred; Use liabilityShift
         // to determine if the payment should be captured
-        //
 
         const paymentToken = await createPaymentToken({
           vaultSetupToken,
@@ -62,18 +65,27 @@ async function onPayClick(cardFieldsInstance) {
         console.log("Payment method saved", paymentToken);
         console.log("vault setup token:", vaultSetupToken);
 
-        // TODO: show success UI, redirect, etc.
+        renderAlert({
+          type: "success",
+          message: "Payment method saved!",
+        });
+
         break;
       }
       case "canceled": {
-        // Buyer dismissed 3DS modal or canceled the flow
-        // TODO: show non-blocking message & allow retry
+        renderAlert({
+          type: "warning",
+          message: "Save payment flow canceled.",
+        });
         break;
       }
       case "failed": {
         // Validation or processing failure. data.message may be present
         console.error("Card submission failed", data);
-        // TODO: surface error to buyer, allow retry
+        renderAlert({
+          type: "danger",
+          message: `Validation or processing failure: ${data.message ?? ""}`,
+        });
         break;
       }
       default: {
@@ -81,8 +93,12 @@ async function onPayClick(cardFieldsInstance) {
         console.warn("Unhandled submit state", state, data);
       }
     }
-  } catch (err) {
-    console.error("Payment flow error", err);
+  } catch (error) {
+    renderAlert({
+      type: "danger",
+      message: `Payment flow error: ${error.message}`,
+    });
+    console.error("Payment flow error", error);
     // TODO: Show generic error and allow retry
   }
 }
@@ -134,4 +150,14 @@ async function createPaymentToken({ vaultSetupToken }) {
   const data = await response.json();
 
   return data;
+}
+
+function renderAlert({ type, message }) {
+  const alertComponentElement = document.querySelector("alert-component");
+  if (!alertComponentElement) {
+    return;
+  }
+
+  alertComponentElement.setAttribute("type", type);
+  alertComponentElement.innerText = message;
 }

--- a/client/components/cardFields/savePayment/html/src/app.js
+++ b/client/components/cardFields/savePayment/html/src/app.js
@@ -44,6 +44,7 @@ async function setupCardFields(sdkInstance) {
   document.querySelector("#paypal-card-fields-expiry").appendChild(expiryField);
 
   const payButton = document.querySelector("#save-payment-method-button");
+  payButton.removeAttribute("hidden");
   payButton.addEventListener("click", () => onPayClick(cardFieldsInstance));
 }
 
@@ -55,10 +56,6 @@ async function onPayClick(cardFieldsInstance) {
 
     switch (state) {
       case "succeeded": {
-        const { vaultSetupToken, ...liabilityShift } = data;
-        // 3DS may or may not have occurred; Use liabilityShift
-        // to determine if the payment should be captured
-
         const paymentToken = await createPaymentToken({
           vaultSetupToken,
         });
@@ -69,7 +66,6 @@ async function onPayClick(cardFieldsInstance) {
           type: "success",
           message: "Payment method saved!",
         });
-
         break;
       }
       case "canceled": {

--- a/client/components/cardFields/savePayment/html/src/index.html
+++ b/client/components/cardFields/savePayment/html/src/index.html
@@ -26,7 +26,7 @@
       <div class="card-field" id="paypal-card-fields-cvv"></div>
       <div class="card-field" id="paypal-card-fields-expiry"></div>
     </div>
-    <button id="save-payment-method-button" class="save-payment-method-button">
+    <button id="save-payment-method-button" class="save-payment-method-button" hidden>
       Save Payment
     </button>
     <alert-component></alert-component>

--- a/client/components/cardFields/savePayment/html/src/index.html
+++ b/client/components/cardFields/savePayment/html/src/index.html
@@ -29,6 +29,8 @@
     <button id="save-payment-method-button" class="save-payment-method-button">
       Save Payment
     </button>
+    <alert-component></alert-component>
+
     <script src="app.js"></script>
 
     <script
@@ -36,5 +38,7 @@
       src="https://www.sandbox.paypal.com/web-sdk/v6/core"
       onload="onPayPalWebSdkLoaded()"
     ></script>
+
+    <script async src="/client/shared/alert-component.js"></script>
   </body>
 </html>

--- a/client/components/cardFields/savePayment/html/src/index.html
+++ b/client/components/cardFields/savePayment/html/src/index.html
@@ -26,7 +26,11 @@
       <div class="card-field" id="paypal-card-fields-cvv"></div>
       <div class="card-field" id="paypal-card-fields-expiry"></div>
     </div>
-    <button id="save-payment-method-button" class="save-payment-method-button" hidden>
+    <button
+      id="save-payment-method-button"
+      class="save-payment-method-button"
+      hidden
+    >
       Save Payment
     </button>
     <alert-component></alert-component>

--- a/server/node/src/routes/ordersRouteHandler.ts
+++ b/server/node/src/routes/ordersRouteHandler.ts
@@ -444,6 +444,8 @@ export async function createOrderForCardWithThreeDSecureRouteHandler(
       card: {
         attributes: {
           verification: {
+            // use "ScaAlways" to test 3D Secure
+            // https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/
             method: OrdersCardVerificationMethod.ScaAlways,
           },
         },


### PR DESCRIPTION
This PR includes a few improvements to the unbranded card fields component examples:
1. display alerts in the UI for success and failure use cases
2. show the liabilityShift value in the error message for the 3DS failure use case
3. hide the card form submit button until the card form is eligibile to be rendered