### PR TITLE
feat: add Bank ACH Wallet one-time payment demo

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,6 @@ PAYPAL_SANDBOX_CLIENT_ID=
 PAYPAL_SANDBOX_CLIENT_SECRET=
 
 # Provide a comma-separated list of the domain names where
-# the Fastlane component will be presented
+# the Fastlane component and the Bank ACH Wallet payment flow will be presented
 # ex: DOMAINS=your-domain.com,your-domain2.com
 DOMAINS=

--- a/client/components/bankAchPayments/walletPayment/html/README.md
+++ b/client/components/bankAchPayments/walletPayment/html/README.md
@@ -1,0 +1,19 @@
+# Bank ACH Wallet Payments HTML Sample Integration
+
+This sample integration uses HTML, JavaScript, and CSS. It does not require a build process to transpile the source code. It's just static files that can be served up by any web server.
+
+This example accepts ACH direct debit payments with the PayPal-hosted `bank-ach-wallet-payments` element. Buyers can either link and verify a bank account through an Open Banking provider or pay with a bank account saved in their PayPal Wallet.
+
+## How it works
+
+1. The client fetches a browser-safe client token and creates a JavaScript SDK v6 instance with the `bank-ach-payments` component. A client token is required because the SDK looks up the buyer's saved bank account in their PayPal Wallet.
+2. `findEligibleMethods()` confirms that ACH is available for the transaction.
+3. `createBankAchWalletPaymentSession()` creates the wallet payment session, and `walletSession.connect()` connects the `bank-ach-wallet-payments` element to a lazy order-creation callback.
+4. When the buyer accepts the ACH mandate, the SDK calls `onApprove()` with the order ID.
+5. A single server endpoint (`/paypal-api/checkout/orders/:orderId/capture-ach-wallet`) retrieves the order details, stores the buyer's authorization (consent) record for NACHA compliance, and captures the payment.
+
+## Testing
+
+ACH direct debit is available only to US merchants and supports payments only in US dollars. See the [Accept ACH payments](https://developer.paypal.com/limited-release/accept-ach-payments) guide for sandbox test credentials for both the PayPal Wallet bank path and the Open Banking path.
+
+This static example is hosted by the [server application](../../../../../server/node/README.md).

--- a/client/components/bankAchPayments/walletPayment/html/src/recommended/app.js
+++ b/client/components/bankAchPayments/walletPayment/html/src/recommended/app.js
@@ -1,0 +1,199 @@
+/**
+ * Bank ACH Wallet One-Time Payment Integration
+ *
+ * This module accepts ACH direct debit payments using PayPal's v6 Web SDK and
+ * the PayPal-hosted `bank-ach-wallet-payments` element. Buyers can link a bank
+ * account through Open Banking or pay with a bank account saved in their PayPal
+ * Wallet. This flow requires a client token because the SDK looks up the buyer's
+ * saved bank account in their PayPal Wallet.
+ */
+
+/**
+ * Main setup function called when the PayPal Web SDK is loaded.
+ * Creates the SDK instance, checks ACH eligibility, and wires up the element.
+ *
+ * @returns {Promise<void>}
+ */
+async function onPayPalWebSdkLoaded() {
+  try {
+    // This integration requires a client token. Because the SDK looks up the
+    // buyer's saved bank account in their PayPal Wallet, client-ID-only
+    // integrations are not supported for the ACH wallet flow.
+    const clientToken = await getBrowserSafeClientToken();
+    const sdkInstance = await window.paypal.createInstance({
+      clientToken,
+      // A unique identifier for this checkout session, used for risk evaluation
+      clientMetadataId: crypto.randomUUID(),
+      components: ["bank-ach-payments"],
+      pageType: "checkout",
+    });
+
+    const paymentMethods = await sdkInstance.findEligibleMethods({
+      currencyCode: "USD",
+      paymentFlow: "ONE_TIME_PAYMENT",
+      amount: "100.00",
+    });
+
+    if (paymentMethods.isEligible("ach")) {
+      configureBankAchWalletPayment(sdkInstance);
+    } else {
+      renderAlert({ type: "warning", message: "Bank ACH is not eligible" });
+    }
+  } catch (error) {
+    renderAlert({
+      type: "danger",
+      message: `Bank ACH setup failed: ${error.message}`,
+    });
+    console.error(error);
+  }
+}
+
+/**
+ * Creates the ACH wallet payment session and connects the
+ * `bank-ach-wallet-payments` element to a lazy order-creation callback.
+ *
+ * @param {Object} sdkInstance - PayPal SDK instance
+ * @returns {void}
+ */
+function configureBankAchWalletPayment(sdkInstance) {
+  const walletSession = sdkInstance.createBankAchWalletPaymentSession({
+    // Optional NACHA Standard Entry Class (SEC) code. Defaults to "WEB".
+    standardEntryClassCode: "WEB",
+    async onApprove(data) {
+      console.log("onApprove", data);
+      try {
+        // The single capture endpoint retrieves the order details, stores the
+        // buyer's authorization (consent) record for NACHA compliance, and
+        // captures the payment.
+        const orderData = await captureOrder({ orderId: data.orderId });
+        renderAlert({
+          type: "success",
+          message: `Order successfully captured! ${JSON.stringify(data)}`,
+        });
+        console.log("Capture result", orderData);
+      } catch (error) {
+        renderAlert({
+          type: "danger",
+          message: `Payment capture failed: ${error.message}`,
+        });
+        console.error(error);
+      }
+    },
+    onError(error) {
+      renderAlert({
+        type: "danger",
+        message: `onError() callback called: ${error.message ?? error}`,
+      });
+      console.log("onError", error);
+    },
+  });
+
+  const bankAchWalletElement = document.querySelector(
+    "bank-ach-wallet-payments",
+  );
+  bankAchWalletElement.removeAttribute("hidden");
+
+  // Connect the rendered element with a lazy order-creation callback. The SDK
+  // calls the callback only when the buyer proceeds with the payment flow.
+  const createOrderSession = () => createOrder();
+  walletSession.connect("bank-ach-wallet-payments", createOrderSession);
+}
+
+/**
+ * Fetches a browser-safe client token from the server.
+ *
+ * @returns {Promise<string>} The client token access token
+ * @throws {Error} If the request fails
+ */
+async function getBrowserSafeClientToken() {
+  const response = await fetch("/paypal-api/auth/browser-safe-client-token", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error("Failed to fetch client token");
+  }
+  const { accessToken } = await response.json();
+
+  return accessToken;
+}
+
+/**
+ * Creates an order on the server for the one-time ACH payment.
+ *
+ * @returns {Promise<{orderId: string}>} The created order ID
+ * @throws {Error} If order creation fails
+ */
+async function createOrder() {
+  const response = await fetch(
+    "/paypal-api/checkout/orders/create-order-for-one-time-payment",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      `Order creation failed ${data ? JSON.stringify(data) : ""}`,
+    );
+  }
+
+  renderAlert({
+    type: "info",
+    message: `Order successfully created: ${data.id}`,
+  });
+
+  return { orderId: data.id };
+}
+
+/**
+ * Captures the approved order via the single ACH wallet capture endpoint, which
+ * also stores the buyer's authorization (consent) record for NACHA compliance.
+ *
+ * @param {Object} params
+ * @param {string} params.orderId - The approved order ID to capture
+ * @returns {Promise<Object>} The capture result
+ * @throws {Error} If the capture fails
+ */
+async function captureOrder({ orderId }) {
+  const response = await fetch(
+    `/paypal-api/checkout/orders/${orderId}/capture-ach-wallet`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(`Order capture failed ${data?.name ?? ""}`);
+  }
+
+  return data;
+}
+
+/**
+ * Renders a message in the shared alert component.
+ *
+ * @param {Object} params
+ * @param {("success"|"info"|"warning"|"danger")} params.type - Alert type
+ * @param {string} params.message - Message to display
+ * @returns {void}
+ */
+function renderAlert({ type, message }) {
+  const alertComponentElement = document.querySelector("alert-component");
+  if (!alertComponentElement) {
+    return;
+  }
+
+  alertComponentElement.setAttribute("type", type);
+  alertComponentElement.innerText = message;
+}

--- a/client/components/bankAchPayments/walletPayment/html/src/recommended/index.html
+++ b/client/components/bankAchPayments/walletPayment/html/src/recommended/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>
+      Bank ACH Wallet Payments - One-time Payment Flow - PayPal Web SDK
+    </title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/client/shared/styles.css" />
+    <style>
+      alert-component {
+        max-width: 50rem;
+        margin-top: 4rem;
+      }
+
+      bank-ach-wallet-payments {
+        display: block;
+        max-width: 30rem;
+        margin-top: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Bank ACH Wallet Payments</h1>
+    <p>
+      This is the recommended integration pattern for accepting ACH direct debit
+      payments with the PayPal-hosted <code>bank-ach-wallet-payments</code>
+      element. Buyers can link a bank account through Open Banking or pay with a
+      bank account saved in their PayPal Wallet.
+    </p>
+
+    <!-- The bank-ach-wallet-payments element renders the email-capture,
+         saved-account mandate, and open banking flow -->
+    <bank-ach-wallet-payments hidden></bank-ach-wallet-payments>
+    <alert-component></alert-component>
+
+    <script src="app.js"></script>
+
+    <script
+      async
+      src="https://www.sandbox.paypal.com/web-sdk/v6/core"
+      onload="onPayPalWebSdkLoaded()"
+    ></script>
+
+    <script async src="/client/shared/alert-component.js"></script>
+  </body>
+</html>

--- a/client/index.html
+++ b/client/index.html
@@ -204,6 +204,12 @@
               >Recommended integration for Bank ACH</a
             >
           </li>
+          <li>
+            <a
+              href="/client/components/bankAchPayments/walletPayment/html/src/recommended/index.html"
+              >Recommended integration for Bank ACH Wallet</a
+            >
+          </li>
         </ul>
       </li>
       <li>

--- a/server/node/src/routes/index.ts
+++ b/server/node/src/routes/index.ts
@@ -15,6 +15,7 @@ import {
   createOrderForCardWithThreeDSecureRouteHandler,
   getOrderRouteHandler,
   captureOrderRouteHandler,
+  captureAchWalletOrderRouteHandler,
 } from "./ordersRouteHandler";
 
 import {
@@ -76,6 +77,11 @@ router.get("/paypal-api/checkout/orders/:orderId", getOrderRouteHandler);
 router.post(
   "/paypal-api/checkout/orders/:orderId/capture",
   captureOrderRouteHandler,
+);
+
+router.post(
+  "/paypal-api/checkout/orders/:orderId/capture-ach-wallet",
+  captureAchWalletOrderRouteHandler,
 );
 
 router.post(

--- a/server/node/src/routes/ordersRouteHandler.ts
+++ b/server/node/src/routes/ordersRouteHandler.ts
@@ -520,3 +520,78 @@ export async function captureOrderRouteHandler(
 
   response.status(statusCode).json(result);
 }
+
+/**
+ * Persists the buyer's authorization (consent) record to comply with NACHA.
+ *
+ * PayPal does not store the authorization on your behalf, so you must store it
+ * for every ACH transaction. Storage is hosted by the merchant. This demo just
+ * logs the record to the console.
+ *
+ * @param authorizationRecord - The consent record to persist
+ */
+async function storeConsent(authorizationRecord: Record<string, unknown>) {
+  console.log(
+    "Storing ACH authorization (consent) record for NACHA compliance:",
+    authorizationRecord,
+  );
+}
+
+/**
+ * Single endpoint for the ACH wallet flow: retrieves the order details, stores
+ * the buyer's authorization (consent) record for NACHA compliance, then captures
+ * the payment. The order status must be APPROVED before you capture.
+ *
+ * @param request - Express request; `params.orderId` is the approved order ID
+ * @param response - Express response
+ */
+export async function captureAchWalletOrderRouteHandler(
+  request: Request,
+  response: Response,
+) {
+  const { orderId } = z.object({ orderId: z.string() }).parse(request.params);
+
+  // 1. Retrieve order details to build the NACHA authorization record.
+  const { result: orderDetails, statusCode: getStatusCode } =
+    await ordersController.getOrder({ id: orderId });
+
+  if (getStatusCode !== 200) {
+    return response.status(getStatusCode).json(orderDetails);
+  }
+
+  // 2. Store the buyer's authorization (consent) record for NACHA compliance.
+  // The ACH debit details live under payment_source.bank.ach_debit, which the
+  // server SDK's PaymentSourceResponse type does not model, so we read it
+  // defensively.
+  const achDebit = (
+    orderDetails.paymentSource as
+      | {
+          bank?: {
+            achDebit?: {
+              bankName?: string;
+              lastDigits?: string;
+              accountHolderName?: string;
+            };
+          };
+        }
+      | undefined
+  )?.bank?.achDebit;
+  await storeConsent({
+    orderId,
+    bankName: achDebit?.bankName,
+    lastDigits: achDebit?.lastDigits,
+    accountHolderName: achDebit?.accountHolderName,
+    amount: orderDetails.purchaseUnits?.[0]?.amount?.value,
+    currencyCode: orderDetails.purchaseUnits?.[0]?.amount?.currencyCode,
+    authorizedAt: new Date().toISOString(),
+  });
+
+  // 3. Capture the payment.
+  const { result, statusCode } = await ordersController.captureOrder({
+    id: orderId,
+    prefer: "return=minimal",
+    paypalRequestId: randomUUID(),
+  });
+
+  response.status(statusCode).json(result);
+}


### PR DESCRIPTION
## Summary

Adds a new sample integration demonstrating the **Bank ACH Wallet one-time payment** flow using PayPal's JavaScript SDK v6 and the PayPal-hosted `bank-ach-wallet-payments` element.

This is distinct from the existing button-based Bank ACH demo (`bankAchPayments/oneTimePayment`). The wallet element supports two buyer paths:
- **Banks in PayPal Wallet** — buyer enters their PayPal email, logs in, and pays with a saved bank account.
- **Open Banking** — buyer links and verifies a bank account through an Open Banking provider.

## Changes

**Client** (`client/components/bankAchPayments/walletPayment/html/src/recommended/`)
- `index.html` — renders the `bank-ach-wallet-payments` element and shared alert component.
- `app.js` — fetches a browser-safe client token (required, since the SDK looks up the buyer's saved bank account), creates the SDK instance with `clientMetadataId`, checks ACH eligibility via `findEligibleMethods`, creates the wallet session with `createBankAchWalletPaymentSession` (`standardEntryClassCode: "WEB"`), and connects the element to a lazy order-creation callback. `onApprove` captures via the ACH wallet endpoint.
- `README.md` — documents the flow.

**Server** (`server/node/src/routes/`)
- `ordersRouteHandler.ts` — new `captureAchWalletOrderRouteHandler`: a single endpoint that retrieves the order details, stores the buyer's authorization (consent) record for NACHA compliance, then captures the payment. Order creation reuses the existing one-time-payment endpoint.
- `index.ts` — registers `POST /paypal-api/checkout/orders/:orderId/capture-ach-wallet`.

**Other**
- `client/index.html` — adds a landing-page link to the new demo.
- `.env.sample` — notes that `DOMAINS` applies to the Bank ACH Wallet flow as well as Fastlane.

## Notes
- This flow requires a **client token** (client-ID-only integrations are not supported).
- ACH direct debit is available only to US merchants and supports payments only in USD; non-eligible accounts show a "Bank ACH is not eligible" message.
- JSDoc conventions applied to the new/changed JS/TS functions.

## Testing

## Email Capture Component
<img width="1509" height="885" alt="EmailCapture" src="https://github.com/user-attachments/assets/da531455-66a1-4bf0-b9ff-5b701864e742" />

## Remember Me Bank Mandate Component
<img width="1509" height="885" alt="RememberMeMandate" src="https://github.com/user-attachments/assets/915590b8-d2d7-4415-9933-647ac9ac5711" />

## Open Banking Bank Mandate Component
<img width="1509" height="885" alt="OpenBankingMandate" src="https://github.com/user-attachments/assets/681a99ef-e74b-4a5d-9460-e8896ee5a6ec" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)