### PR TITLE
feat: add basic Apple Pay one-time payment example

### DIFF
--- a/client/components/applepayPayments/basicOneTimePayment/html/src/app.js
+++ b/client/components/applepayPayments/basicOneTimePayment/html/src/app.js
@@ -1,0 +1,198 @@
+const COUNTRY_TO_CURRENCY = { US: "USD", MX: "MXN", BR: "BRL" };
+
+let currentCurrencyCode;
+
+async function onPayPalWebSdkLoaded() {
+  try {
+    // Using a clientToken (instead of a bare clientId) lets the Web SDK
+    // derive the merchantId it needs internally from the token itself, so
+    // there's no separate Merchant ID to configure for this example.
+    const clientToken = await getBrowserSafeClientToken();
+    const sdkInstance = await window.paypal.createInstance({
+      clientToken,
+      components: ["applepay-payments"],
+      pageType: "checkout",
+    });
+
+    const countrySelect = document.getElementById("country-select");
+    const currencyDisplay = document.getElementById("currency-display");
+    currentCurrencyCode = COUNTRY_TO_CURRENCY[countrySelect.value];
+
+    // The country/currency selector only affects what currency is used when
+    // creating the order below; Apple Pay eligibility itself doesn't depend
+    // on currency, so there's no need to re-run findEligibleMethods here.
+    countrySelect.addEventListener("change", () => {
+      currentCurrencyCode = COUNTRY_TO_CURRENCY[countrySelect.value];
+      currencyDisplay.value = currentCurrencyCode;
+    });
+
+    const eligibility = await sdkInstance.findEligibleMethods();
+
+    if (!eligibility.isEligible("basic_apple_pay")) {
+      return renderAlert({
+        type: "warning",
+        message: "Basic Apple Pay is not eligible",
+      });
+    }
+
+    const applePayPaymentSession =
+      await sdkInstance.createBasicApplePayOneTimePaymentSession({
+        onApprove: async ({ orderId }) => {
+          console.log(`Payment approved, capturing order ${orderId}...`);
+          const orderData = await captureOrder({ orderId });
+          console.log(JSON.stringify(orderData, null, 2));
+          renderAlert({
+            type: "success",
+            message: `Order captured successfully: ${orderId}`,
+          });
+        },
+        onCancel: () => {
+          renderAlert({ type: "info", message: "Payment cancelled" });
+        },
+        onError: (error) => {
+          console.error(error);
+          renderAlert({
+            type: "danger",
+            message: `Payment error: ${error.message ?? error}`,
+          });
+        },
+      });
+
+    if (!(await applePayPaymentSession.canMakePayments())) {
+      return renderAlert({
+        type: "warning",
+        message: "This device cannot make Apple Pay payments",
+      });
+    }
+
+    document.getElementById("payment-method-radio-group").hidden = false;
+    configureApplePayButton(applePayPaymentSession);
+  } catch (error) {
+    console.error(error);
+    renderAlert({
+      type: "danger",
+      message: `Failed to initialize Apple Pay: ${error.message ?? error}`,
+    });
+  }
+}
+
+function configureApplePayButton(applePayPaymentSession) {
+  const applePayButton = createApplePayButton();
+  applePayButton.addEventListener("click", () =>
+    onApplePayButtonClick(applePayPaymentSession),
+  );
+  document
+    .getElementById("apple-pay-button-container")
+    .appendChild(applePayButton);
+}
+
+async function onApplePayButtonClick(applePayPaymentSession) {
+  try {
+    const checkoutSessionOptionsPromise = createOrder(
+      currentCurrencyCode,
+    ).then(({ orderId }) => ({ orderId }));
+    // The Web SDK drives the entire Apple Pay sheet (merchant validation,
+    // payment method selection, and authorization) on your behalf.
+    await applePayPaymentSession.start({}, checkoutSessionOptionsPromise);
+  } catch (error) {
+    console.error(error);
+    renderAlert({
+      type: "danger",
+      message: `Payment cancelled or failed: ${error.message ?? error}`,
+    });
+  }
+}
+
+function createApplePayButton() {
+  const applePayButton = document.createElement("button");
+  applePayButton.id = "apple-pay-button";
+  applePayButton.textContent = "Checkout";
+  return applePayButton;
+}
+
+async function getBrowserSafeClientToken() {
+  const response = await fetch("/paypal-api/auth/browser-safe-client-token", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    const message = `Failed to get browser-safe client token: ${response.status} ${response.statusText}${errorBody ? ` - ${errorBody}` : ""}`;
+    renderAlert({ type: "danger", message });
+    throw new Error(message);
+  }
+
+  const { accessToken } = await response.json();
+
+  return accessToken;
+}
+
+async function createOrder(currencyCode) {
+  const response = await fetch(
+    "/paypal-api/checkout/orders/create-order-for-one-time-payment",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        cart: [
+          {
+            // $20 amount (2 baseballs at $10 each)
+            sku: "3xk9m4n2",
+            quantity: 2,
+          },
+        ],
+        currencyCode,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    const message = `Failed to create order: ${response.status} ${response.statusText}${errorBody ? ` - ${errorBody}` : ""}`;
+    renderAlert({ type: "danger", message });
+    throw new Error(message);
+  }
+
+  const { id } = await response.json();
+  renderAlert({ type: "info", message: `Order successfully created: ${id}` });
+
+  return { orderId: id };
+}
+
+async function captureOrder({ orderId }) {
+  const response = await fetch(
+    `/paypal-api/checkout/orders/${orderId}/capture`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    const message = `Failed to capture order ${orderId}: ${response.status} ${response.statusText}${errorBody ? ` - ${errorBody}` : ""}`;
+    renderAlert({ type: "danger", message });
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+
+  return data;
+}
+
+function renderAlert({ type, message }) {
+  const alertComponentElement = document.querySelector("alert-component");
+  if (!alertComponentElement) {
+    return;
+  }
+
+  alertComponentElement.setAttribute("type", type);
+  alertComponentElement.innerText = message;
+}

--- a/client/components/applepayPayments/basicOneTimePayment/html/src/app.js
+++ b/client/components/applepayPayments/basicOneTimePayment/html/src/app.js
@@ -88,9 +88,9 @@ function configureApplePayButton(applePayPaymentSession) {
 
 async function onApplePayButtonClick(applePayPaymentSession) {
   try {
-    const checkoutSessionOptionsPromise = createOrder(
-      currentCurrencyCode,
-    ).then(({ orderId }) => ({ orderId }));
+    const checkoutSessionOptionsPromise = createOrder(currentCurrencyCode).then(
+      ({ orderId }) => ({ orderId }),
+    );
     // The Web SDK drives the entire Apple Pay sheet (merchant validation,
     // payment method selection, and authorization) on your behalf.
     await applePayPaymentSession.start({}, checkoutSessionOptionsPromise);

--- a/client/components/applepayPayments/basicOneTimePayment/html/src/index.html
+++ b/client/components/applepayPayments/basicOneTimePayment/html/src/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>One-Time Payment - Basic Apple Pay - PayPal Web SDK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/client/shared/styles.css" />
+    <style>
+      alert-component {
+        max-width: 50rem;
+        margin-top: 4rem;
+      }
+
+      .payment-config {
+        display: flex;
+        gap: 1rem;
+        align-items: flex-end;
+        margin-bottom: 1.5rem;
+      }
+
+      .payment-config-item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .payment-config-field {
+        height: 40px;
+        padding: 0 0.5rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+      }
+
+      .payment-method-radio-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .payment-method-radio-group[hidden] {
+        display: none;
+      }
+
+      .payment-method-radio-option {
+        display: flex;
+        align-items: center;
+        gap: 0.625rem;
+        padding: 0.75rem;
+        border: 2px solid #e0e0e0;
+        border-radius: 8px;
+        cursor: pointer;
+        width: 20rem;
+      }
+
+      .payment-method-radio-option:has(input:checked) {
+        border-color: #003087;
+      }
+
+      #apple-pay-button {
+        width: 20rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Basic One-Time Payment Apple Pay Integration</h1>
+    <p>
+      This example demonstrates the Basic Apple Pay flow, where the PayPal
+      Web SDK manages the Apple Pay session for you instead of requiring you
+      to drive the Apple Pay JS APIs directly.
+    </p>
+
+    <div class="payment-config">
+      <div class="payment-config-item">
+        <label for="country-select">Country</label>
+        <select id="country-select" class="payment-config-field">
+          <option value="US">US</option>
+          <option value="MX">MX</option>
+          <option value="BR">BR</option>
+        </select>
+      </div>
+      <div class="payment-config-item">
+        <label for="currency-display">Currency</label>
+        <input
+          id="currency-display"
+          class="payment-config-field"
+          type="text"
+          readonly
+          value="USD"
+        />
+      </div>
+    </div>
+
+    <div
+      id="payment-method-radio-group"
+      class="payment-method-radio-group"
+      hidden
+    >
+      <label class="payment-method-radio-option">
+        <input type="radio" name="payment-method" value="apple-pay" checked />
+        <apple-pay-mark></apple-pay-mark>
+      </label>
+    </div>
+
+    <div id="apple-pay-button-container"></div>
+    <alert-component></alert-component>
+
+    <script src="app.js"></script>
+
+    <script
+      async
+      src="https://www.sandbox.paypal.com/web-sdk/v6/core"
+      onload="onPayPalWebSdkLoaded()"
+    ></script>
+    <!--
+      Note: unlike the recommended ApplePay integration, the Basic ApplePay
+      flow is managed entirely by the PayPal Web SDK, so Apple's own
+      apple-pay-sdk.js script is not required here.
+    -->
+
+    <!-- Provides the <apple-pay-mark> custom element used above -->
+    <script async src="https://www.sandbox.paypal.com/web-sdk/v6/brand"></script>
+
+    <script async src="/client/shared/alert-component.js"></script>
+  </body>
+</html>

--- a/client/components/applepayPayments/basicOneTimePayment/html/src/index.html
+++ b/client/components/applepayPayments/basicOneTimePayment/html/src/index.html
@@ -65,9 +65,9 @@
   <body>
     <h1>Basic One-Time Payment Apple Pay Integration</h1>
     <p>
-      This example demonstrates the Basic Apple Pay flow, where the PayPal
-      Web SDK manages the Apple Pay session for you instead of requiring you
-      to drive the Apple Pay JS APIs directly.
+      This example demonstrates the Basic Apple Pay flow, where the PayPal Web
+      SDK manages the Apple Pay session for you instead of requiring you to
+      drive the Apple Pay JS APIs directly.
     </p>
 
     <div class="payment-config">
@@ -119,7 +119,10 @@
     -->
 
     <!-- Provides the <apple-pay-mark> custom element used above -->
-    <script async src="https://www.sandbox.paypal.com/web-sdk/v6/brand"></script>
+    <script
+      async
+      src="https://www.sandbox.paypal.com/web-sdk/v6/brand"
+    ></script>
 
     <script async src="/client/shared/alert-component.js"></script>
   </body>

--- a/client/index.html
+++ b/client/index.html
@@ -176,6 +176,12 @@
               >One-time payment with Vault for ApplePay</a
             >
           </li>
+          <li>
+            <a
+              href="/client/components/applepayPayments/basicOneTimePayment/html/src/index.html"
+              >Basic Apple Pay one-time payment</a
+            >
+          </li>
         </ul>
       </li>
       <li>


### PR DESCRIPTION
Adds a standalone HTML/JS integration example for Apple Pay under applepayPayments/basicOneTimePayment and links it from the client index.