### PR TITLE
Revert "chore: limit custom approver list to codeowner file only"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,5 @@
 ###############
 * @paypal-examples/web-sdk
 
-# Changes to this file have to be approved by the below folks
-/.github/CODEOWNERS @gregjopa @wsbrunson @bdellis @imbrian
+# Changes to this has to be approved by the below folks
+/.github/ @gregjopa @wsbrunson @bdellis


### PR DESCRIPTION
Reverts paypal-examples/v6-web-sdk-sample-integration#119